### PR TITLE
feat(android): Kotlin Android sample app with uniffi bindings

### DIFF
--- a/android/sample-app/app/build.gradle.kts
+++ b/android/sample-app/app/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.activity:activity-compose:1.9.3")
     implementation(platform("androidx.compose:compose-bom:2024.12.01"))
     implementation("androidx.compose.ui:ui")


### PR DESCRIPTION
## Android Sample App

Kotlin Android app consuming hw-core via uniffi bindings.

### Structure
- `android/` — Rust uniffi library crate (exposes hw-core over FFI)
- `android/sample-app/` — Jetpack Compose Android app

### App flow
Home → Scan (5s BLE discovery) → Connect (THP handshake + auto-pair) → Pairing (6-digit code or confirmation) → Ready (get ETH address, sign 0 ETH tx to 0xdead)

### Build
```
just build-android        # debug
just build-android-release
```