### PR TITLE
implement TXORIGINPUT, TXORIGOUTPUT, TXPAYMENTREQ handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ android/lib/src/main/java/uniffi/hwcore/hwcore.kt
 android/lib/src/main/java/io/github/gedgygedgy/rust/
 android/lib/src/main/java/com/nonpolynomial/btleplug/
 gradle-daemon-jvm.properties
+# Local Trezor emulator binaries used during development.
 tests/fixtures/trezor-emu-core-*

--- a/android/sample-app/app/src/main/java/dev/hewig/hwcore/MainActivity.kt
+++ b/android/sample-app/app/src/main/java/dev/hewig/hwcore/MainActivity.kt
@@ -619,6 +619,25 @@ fun MainScreen(
                         }
 
                         Chain.BITCOIN -> {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                OutlinedButton(
+                                    onClick = vm::loadBitcoinBasicPreset,
+                                    enabled = !ui.isBusy,
+                                    modifier = Modifier.weight(1f),
+                                ) {
+                                    Text("Load Basic")
+                                }
+                                OutlinedButton(
+                                    onClick = vm::loadBitcoinAdvancedPreset,
+                                    enabled = !ui.isBusy,
+                                    modifier = Modifier.weight(1f),
+                                ) {
+                                    Text("Load RBF Preset")
+                                }
+                            }
                             OutlinedTextField(
                                 value = ui.btcTxJsonInput,
                                 onValueChange = vm::updateBitcoinTxJson,
@@ -632,7 +651,7 @@ fun MainScreen(
                                 textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                             )
                             Text(
-                                text = "BTC signing requires ref_txs that match each input prev_hash/prev_index.",
+                                text = "BTC signing accepts basic ref_txs plus advanced orig_txs for RBF. Real Bitcoin payment requests need a fresh device nonce, authenticated address MACs, and a merchant signature, so they are not covered by the built-in preset.",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )

--- a/android/sample-app/app/src/main/java/dev/hewig/hwcore/MainViewModel.kt
+++ b/android/sample-app/app/src/main/java/dev/hewig/hwcore/MainViewModel.kt
@@ -135,6 +135,147 @@ private const val DEFAULT_BITCOIN_TX_JSON = """
 }
 """
 
+private const val ADVANCED_BITCOIN_TX_JSON = """
+{
+  "description": "RBF fee-bump scenario with original tx data for real-device testing.",
+  "version": 2,
+  "lock_time": 831400,
+  "inputs": [
+    {
+      "path": "m/84'/0'/0'/0/3",
+      "prev_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "prev_index": 0,
+      "amount": "50000",
+      "sequence": 4294967293,
+      "script_type": "spendwitness",
+      "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "orig_index": 0
+    },
+    {
+      "path": "m/84'/0'/0'/0/7",
+      "prev_hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+      "prev_index": 1,
+      "amount": "30000",
+      "sequence": 4294967293,
+      "script_type": "spendwitness",
+      "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "orig_index": 1
+    }
+  ],
+  "outputs": [
+    {
+      "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      "amount": "60000",
+      "script_type": "paytowitness",
+      "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "orig_index": 0
+    },
+    {
+      "path": "m/84'/0'/0'/1/2",
+      "amount": "18500",
+      "script_type": "paytowitness",
+      "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "orig_index": 1
+    }
+  ],
+  "ref_txs": [
+    {
+      "hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "version": 2,
+      "lock_time": 831200,
+      "inputs": [
+        {
+          "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "prev_index": 0,
+          "script_sig": "",
+          "sequence": 4294967293
+        }
+      ],
+      "bin_outputs": [
+        {
+          "amount": "50000",
+          "script_pubkey": "00149d5e0fb75d36c7b94c0dc4c03e3c8f0b68e23e71"
+        },
+        {
+          "amount": "49000",
+          "script_pubkey": "0014d85c2b71d0060b09c9886aeb815e50991dda124d"
+        }
+      ]
+    },
+    {
+      "hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+      "version": 2,
+      "lock_time": 831100,
+      "inputs": [
+        {
+          "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "prev_index": 0,
+          "script_sig": "",
+          "sequence": 4294967293
+        },
+        {
+          "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
+          "prev_index": 2,
+          "script_sig": "483045022100abcdef",
+          "sequence": 4294967293
+        }
+      ],
+      "bin_outputs": [
+        {
+          "amount": "10000",
+          "script_pubkey": "0014a11ce08a1b5c4b1f1b8e3ea8dbb7f26f60e2c1a0"
+        },
+        {
+          "amount": "30000",
+          "script_pubkey": "001425e03ad0c5c96b45920de82fc2e2e84c72e3f5ab"
+        }
+      ]
+    }
+  ],
+  "orig_txs": [
+    {
+      "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "version": 2,
+      "lock_time": 831350,
+      "inputs": [
+        {
+          "path": "m/84'/0'/0'/0/3",
+          "prev_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "prev_index": 0,
+          "amount": "50000",
+          "sequence": 4294967293,
+          "script_type": "spendwitness",
+          "script_sig": "",
+          "witness": "0x024730"
+        },
+        {
+          "path": "m/84'/0'/0'/0/7",
+          "prev_hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+          "prev_index": 1,
+          "amount": "30000",
+          "sequence": 4294967293,
+          "script_type": "spendwitness",
+          "script_sig": "",
+          "witness": "0x034731"
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+          "amount": "60000",
+          "script_type": "paytowitness"
+        },
+        {
+          "path": "m/84'/0'/0'/1/2",
+          "amount": "19000",
+          "script_type": "paytowitness"
+        }
+      ]
+    }
+  ]
+}
+"""
+
 class MainViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
 
     private var uiState by mutableStateOf(UiState())
@@ -983,6 +1124,8 @@ class MainViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel(
     fun setSolChunkify(value: Boolean) { ui = ui.copy(solChunkify = value) }
 
     fun updateBitcoinTxJson(value: String) { ui = ui.copy(btcTxJsonInput = value) }
+    fun loadBitcoinBasicPreset() { ui = ui.copy(btcTxJsonInput = DEFAULT_BITCOIN_TX_JSON.trimIndent()) }
+    fun loadBitcoinAdvancedPreset() { ui = ui.copy(btcTxJsonInput = ADVANCED_BITCOIN_TX_JSON.trimIndent()) }
 
     fun signPreview(): String {
         val state = ui
@@ -1208,7 +1351,9 @@ class MainViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel(
             val inputs = obj.optJSONArray("inputs")?.length() ?: 0
             val outputs = obj.optJSONArray("outputs")?.length() ?: 0
             val refTxs = obj.optJSONArray("ref_txs")?.length() ?: 0
-            "inputs=$inputs outputs=$outputs ref_txs=$refTxs"
+            val origTxs = obj.optJSONArray("orig_txs")?.length() ?: 0
+            val paymentReqs = obj.optJSONArray("payment_reqs")?.length() ?: 0
+            "inputs=$inputs outputs=$outputs ref_txs=$refTxs orig_txs=$origTxs payment_reqs=$paymentReqs"
         } catch (_: Exception) {
             null
         }

--- a/apple/HWCoreKit/Sources/HWCoreKit/WalletSession.swift
+++ b/apple/HWCoreKit/Sources/HWCoreKit/WalletSession.swift
@@ -168,6 +168,16 @@ public final class WalletSession: @unchecked Sendable {
         }
     }
 
+    public func getNonce(timeout: TimeInterval? = nil) async throws -> String {
+        do {
+            return try await withTimeout(seconds: timeout, operation: "getNonce") {
+                try await self.workflow.getNonce()
+            }
+        } catch {
+            throw mapError(error)
+        }
+    }
+
     public func signTx(
         _ request: SignTxRequest,
         timeout: TimeInterval? = nil

--- a/apple/HWCoreKitSampleApp/Sources/HWCoreKitSampleApp/ViewModels/ContentViewModel.swift
+++ b/apple/HWCoreKitSampleApp/Sources/HWCoreKitSampleApp/ViewModels/ContentViewModel.swift
@@ -23,6 +23,7 @@ final class ContentViewModel: ObservableObject {
     @Published var isBusy = false
     @Published var address = ""
     @Published var addressPublicKey = ""
+    @Published var nonceResult = ""
     @Published var signatureSummary = ""
     @Published var logs: [String] = []
     @Published var addressPathInput: String
@@ -116,6 +117,146 @@ final class ContentViewModel: ObservableObject {
             {
               "amount": "1000",
               "script_pubkey": "001400112233445566778899aabbccddeeff00112233"
+            }
+          ]
+        }
+      ]
+    }
+    """
+    private static let advancedBitcoinTxJson = """
+    {
+      "description": "RBF fee-bump scenario with original tx data for real-device testing.",
+      "version": 2,
+      "lock_time": 831400,
+      "inputs": [
+        {
+          "path": "m/84'/0'/0'/0/3",
+          "prev_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "prev_index": 0,
+          "amount": "50000",
+          "sequence": 4294967293,
+          "script_type": "spendwitness",
+          "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "orig_index": 0
+        },
+        {
+          "path": "m/84'/0'/0'/0/7",
+          "prev_hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+          "prev_index": 1,
+          "amount": "30000",
+          "sequence": 4294967293,
+          "script_type": "spendwitness",
+          "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "orig_index": 1
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+          "amount": "60000",
+          "script_type": "paytowitness",
+          "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "orig_index": 0
+        },
+        {
+          "path": "m/84'/0'/0'/1/2",
+          "amount": "18500",
+          "script_type": "paytowitness",
+          "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "orig_index": 1
+        }
+      ],
+      "ref_txs": [
+        {
+          "hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "version": 2,
+          "lock_time": 831200,
+          "inputs": [
+            {
+              "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+              "prev_index": 0,
+              "script_sig": "",
+              "sequence": 4294967293
+            }
+          ],
+          "bin_outputs": [
+            {
+              "amount": "50000",
+              "script_pubkey": "00149d5e0fb75d36c7b94c0dc4c03e3c8f0b68e23e71"
+            },
+            {
+              "amount": "49000",
+              "script_pubkey": "0014d85c2b71d0060b09c9886aeb815e50991dda124d"
+            }
+          ]
+        },
+        {
+          "hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+          "version": 2,
+          "lock_time": 831100,
+          "inputs": [
+            {
+              "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
+              "prev_index": 0,
+              "script_sig": "",
+              "sequence": 4294967293
+            },
+            {
+              "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
+              "prev_index": 2,
+              "script_sig": "483045022100abcdef",
+              "sequence": 4294967293
+            }
+          ],
+          "bin_outputs": [
+            {
+              "amount": "10000",
+              "script_pubkey": "0014a11ce08a1b5c4b1f1b8e3ea8dbb7f26f60e2c1a0"
+            },
+            {
+              "amount": "30000",
+              "script_pubkey": "001425e03ad0c5c96b45920de82fc2e2e84c72e3f5ab"
+            }
+          ]
+        }
+      ],
+      "orig_txs": [
+        {
+          "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "version": 2,
+          "lock_time": 831350,
+          "inputs": [
+            {
+              "path": "m/84'/0'/0'/0/3",
+              "prev_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "prev_index": 0,
+              "amount": "50000",
+              "sequence": 4294967293,
+              "script_type": "spendwitness",
+              "script_sig": "",
+              "witness": "0x024730"
+            },
+            {
+              "path": "m/84'/0'/0'/0/7",
+              "prev_hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+              "prev_index": 1,
+              "amount": "30000",
+              "sequence": 4294967293,
+              "script_type": "spendwitness",
+              "script_sig": "",
+              "witness": "0x034731"
+            }
+          ],
+          "outputs": [
+            {
+              "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+              "amount": "60000",
+              "script_type": "paytowitness"
+            },
+            {
+              "path": "m/84'/0'/0'/1/2",
+              "amount": "19000",
+              "script_type": "paytowitness"
             }
           ]
         }
@@ -326,6 +467,24 @@ final class ContentViewModel: ObservableObject {
         }
     }
 
+    func fetchNonce() async {
+        await runAction(prefix: "getNonce") { [self] in
+            guard let session else {
+                status = "Connect first"
+                return
+            }
+            guard sessionState?.canGetAddress == true else {
+                status = "Connect first"
+                return
+            }
+
+            let nonce = try await session.getNonce()
+            nonceResult = nonce
+            status = "Nonce received"
+            appendLog("nonce: \(nonce)")
+        }
+    }
+
     func signSampleTransaction() async {
         await runAction(prefix: "signTx") { [self] in
             guard let session else {
@@ -375,6 +534,7 @@ final class ContentViewModel: ObservableObject {
     func selectedChainDidChange() {
         addressPathInput = defaultPath(for: selectedChain)
         messageSignPathInput = defaultPath(for: selectedChain)
+        nonceResult = ""
         status = "Selected chain: \(chainLabel(selectedChain))"
     }
 
@@ -405,6 +565,10 @@ final class ContentViewModel: ObservableObject {
 
     func copyAddressToClipboard() {
         copyToClipboard(address, emptyMessage: "No address to copy", successLabel: "address")
+    }
+
+    func copyNonceToClipboard() {
+        copyToClipboard(nonceResult, emptyMessage: "No nonce to copy", successLabel: "nonce")
     }
 
     func copySignatureToClipboard() {
@@ -464,6 +628,7 @@ final class ContentViewModel: ObservableObject {
             shouldRecoverOnActive = false
             address = ""
             addressPublicKey = ""
+            nonceResult = ""
             signatureSummary = ""
             logs.removeAll()
 
@@ -652,6 +817,14 @@ final class ContentViewModel: ObservableObject {
         }
     }
 
+    func loadBitcoinBasicPreset() {
+        btcTxJsonInput = Self.defaultBitcoinTxJson
+    }
+
+    func loadBitcoinAdvancedPreset() {
+        btcTxJsonInput = Self.advancedBitcoinTxJson
+    }
+
     private func buildSignRequest(
         chain: Chain,
         session: WalletSession
@@ -800,7 +973,9 @@ final class ContentViewModel: ObservableObject {
         let inputs = (dictionary["inputs"] as? [Any])?.count ?? 0
         let outputs = (dictionary["outputs"] as? [Any])?.count ?? 0
         let refTxs = (dictionary["ref_txs"] as? [Any])?.count ?? 0
-        return "inputs=\(inputs) outputs=\(outputs) ref_txs=\(refTxs)"
+        let origTxs = (dictionary["orig_txs"] as? [Any])?.count ?? 0
+        let paymentReqs = (dictionary["payment_reqs"] as? [Any])?.count ?? 0
+        return "inputs=\(inputs) outputs=\(outputs) ref_txs=\(refTxs) orig_txs=\(origTxs) payment_reqs=\(paymentReqs)"
     }
 
     private func copyToClipboard(_ value: String, emptyMessage: String, successLabel: String) {

--- a/apple/HWCoreKitSampleApp/Sources/HWCoreKitSampleApp/Views/ContentView+iOS.swift
+++ b/apple/HWCoreKitSampleApp/Sources/HWCoreKitSampleApp/Views/ContentView+iOS.swift
@@ -46,7 +46,7 @@ struct MobileContentView: View {
                         deviceCard
                     }
                     actionCard
-                    if !viewModel.address.isEmpty || !viewModel.signatureSummary.isEmpty {
+                    if !viewModel.address.isEmpty || !viewModel.nonceResult.isEmpty || !viewModel.signatureSummary.isEmpty {
                         resultCard
                     }
                 }
@@ -166,6 +166,9 @@ struct MobileContentView: View {
                     }
                     iosActionButton("Address", systemImage: "location.viewfinder", isProminent: false, disabled: !viewModel.canGetAddress, accessibilityID: "action.address") {
                         Task { await viewModel.fetchAddress() }
+                    }
+                    iosActionButton("Nonce", systemImage: "number.square", isProminent: false, disabled: !viewModel.canGetAddress, accessibilityID: "action.nonce") {
+                        Task { await viewModel.fetchNonce() }
                     }
                     iosActionButton("Sign", systemImage: "signature", isProminent: false, disabled: !viewModel.canSign, accessibilityID: "action.sign") {
                         Task { await viewModel.signSampleTransaction() }
@@ -306,8 +309,27 @@ struct MobileContentView: View {
                     .accessibilityIdentifier("result.address.copy")
                 }
 
-                if !viewModel.signatureSummary.isEmpty {
+                if !viewModel.nonceResult.isEmpty {
                     if !viewModel.address.isEmpty {
+                        Divider()
+                    }
+                    Text("Nonce")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(viewModel.nonceResult)
+                        .font(.system(.footnote, design: .monospaced))
+                        .textSelection(.enabled)
+                        .accessibilityLabel("Nonce")
+                        .accessibilityIdentifier("result.nonce")
+                    Button("Copy Nonce") {
+                        viewModel.copyNonceToClipboard()
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("result.nonce.copy")
+                }
+
+                if !viewModel.signatureSummary.isEmpty {
+                    if !viewModel.address.isEmpty || !viewModel.nonceResult.isEmpty {
                         Divider()
                     }
                     Text("Signature")
@@ -381,6 +403,19 @@ struct MobileContentView: View {
             Text("Transaction JSON")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
+            HStack(spacing: 10) {
+                Button("Load Basic") {
+                    viewModel.loadBitcoinBasicPreset()
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("button.sign.btc.load_basic")
+
+                Button("Load RBF Preset") {
+                    viewModel.loadBitcoinAdvancedPreset()
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("button.sign.btc.load_advanced")
+            }
             TextEditor(text: $viewModel.btcTxJsonInput)
                 .font(.system(.footnote, design: .monospaced))
                 .frame(minHeight: 180)
@@ -390,7 +425,7 @@ struct MobileContentView: View {
                         .fill(Color(.secondarySystemBackground))
                 )
                 .accessibilityIdentifier("input.sign.btc.tx_json")
-            Text("BTC signing requires ref_txs that match each input prev_hash/prev_index.")
+            Text("BTC signing requires ref_txs that match each input prev_hash/prev_index. The RBF preset covers orig_txs for real-device testing. Real Bitcoin payment requests also need a fresh device nonce, authenticated address MACs, and a merchant signature, so they are not covered by the built-in preset.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
         }

--- a/apple/HWCoreKitSampleApp/Sources/HWCoreKitSampleApp/Views/ContentView+macOS.swift
+++ b/apple/HWCoreKitSampleApp/Sources/HWCoreKitSampleApp/Views/ContentView+macOS.swift
@@ -93,6 +93,13 @@ struct MacContentView: View {
                 .accessibilityLabel("Get address")
                 .accessibilityIdentifier("action.address")
 
+                Button("Nonce") {
+                    Task { await viewModel.fetchNonce() }
+                }
+                .disabled(!viewModel.canGetAddress)
+                .accessibilityLabel("Get nonce")
+                .accessibilityIdentifier("action.nonce")
+
                 Button("Sign") {
                     Task { await viewModel.signSampleTransaction() }
                 }
@@ -200,6 +207,22 @@ struct MacContentView: View {
                     }
                 }
 
+                if !viewModel.nonceResult.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 8) {
+                            Text("Nonce: \(viewModel.nonceResult)")
+                                .font(.system(.body, design: .monospaced))
+                                .textSelection(.enabled)
+                                .accessibilityLabel("Nonce")
+                                .accessibilityIdentifier("result.nonce")
+                            Button("Copy") {
+                                viewModel.copyNonceToClipboard()
+                            }
+                            .accessibilityIdentifier("result.nonce.copy")
+                        }
+                    }
+                }
+
                 if !viewModel.signatureSummary.isEmpty {
                     VStack(alignment: .leading, spacing: 8) {
                         ScrollView(.horizontal) {
@@ -302,11 +325,22 @@ struct MacContentView: View {
             Text("Transaction JSON")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
+            HStack(spacing: 8) {
+                Button("Load Basic") {
+                    viewModel.loadBitcoinBasicPreset()
+                }
+                .accessibilityIdentifier("button.sign.btc.load_basic")
+
+                Button("Load RBF Preset") {
+                    viewModel.loadBitcoinAdvancedPreset()
+                }
+                .accessibilityIdentifier("button.sign.btc.load_advanced")
+            }
             TextEditor(text: $viewModel.btcTxJsonInput)
                 .font(.system(.footnote, design: .monospaced))
                 .frame(minHeight: 140)
                 .accessibilityIdentifier("input.sign.btc.tx_json")
-            Text("BTC signing requires ref_txs that match each input prev_hash/prev_index.")
+            Text("BTC signing requires ref_txs that match each input prev_hash/prev_index. The RBF preset covers orig_txs for real-device testing. Real Bitcoin payment requests also need a fresh device nonce, authenticated address MACs, and a merchant signature, so they are not covered by the built-in preset.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
         }

--- a/crates/hw-cli/src/commands/test_support.rs
+++ b/crates/hw-cli/src/commands/test_support.rs
@@ -20,6 +20,7 @@ pub struct MockCounters {
     pub credential_calls: usize,
     pub create_session_calls: usize,
     pub get_address_calls: usize,
+    pub get_nonce_calls: usize,
     pub sign_message_calls: usize,
     pub sign_typed_data_calls: usize,
     pub sign_tx_calls: usize,
@@ -218,6 +219,11 @@ impl ThpBackend for MockBackend {
         self.get_address_response.clone().ok_or_else(|| {
             BackendError::Transport("unexpected get_address without canned response".into())
         })
+    }
+
+    async fn get_nonce(&mut self) -> BackendResult<Vec<u8>> {
+        self.counters.get_nonce_calls += 1;
+        Ok(vec![0xAA; 32])
     }
 
     async fn sign_tx(&mut self, request: SignTxRequest) -> BackendResult<SignTxResponse> {

--- a/crates/hw-ffi/src/ble.rs
+++ b/crates/hw-ffi/src/ble.rs
@@ -243,8 +243,27 @@ where
     Ok(AddressResult {
         chain: response.chain,
         address: response.address,
+        mac: response.mac.as_deref().map(hex_prefixed),
         public_key: response.public_key,
     })
+}
+
+fn hex_prefixed(bytes: &[u8]) -> String {
+    let mut value = String::with_capacity(2 + bytes.len() * 2);
+    value.push_str("0x");
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(value, "{byte:02x}");
+    }
+    value
+}
+
+async fn get_nonce_for_workflow<B>(workflow: &mut ThpWorkflow<B>) -> Result<String, HWCoreError>
+where
+    B: trezor_connect::thp::ThpBackend + Send,
+{
+    let nonce = workflow.get_nonce().await.map_err(HWCoreError::from)?;
+    Ok(hex_prefixed(&nonce))
 }
 
 fn map_sign_tx_request(

--- a/crates/hw-ffi/src/ble/tests.rs
+++ b/crates/hw-ffi/src/ble/tests.rs
@@ -221,6 +221,10 @@ impl ThpBackend for MockBackend {
         })
     }
 
+    async fn get_nonce(&mut self) -> BackendResult<Vec<u8>> {
+        Ok(vec![0xAA; 32])
+    }
+
     async fn sign_message(
         &mut self,
         request: BackendSignMessageRequest,
@@ -353,6 +357,10 @@ async fn typed_address_and_sign_requests_map_to_workflow_calls() {
     assert_eq!(
         address.address,
         "0x0fA8844c87c5c8017e2C6C3407812A0449dB91dE"
+    );
+    assert_eq!(
+        address.mac.as_deref(),
+        Some("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     );
     assert_eq!(address.public_key.as_deref(), Some("xpub-test"));
 

--- a/crates/hw-ffi/src/ble/workflow_api.rs
+++ b/crates/hw-ffi/src/ble/workflow_api.rs
@@ -424,6 +424,35 @@ impl BleWorkflowHandle {
     }
 
     #[uniffi::method]
+    pub async fn get_nonce(&self) -> Result<String, HWCoreError> {
+        self.push_event(WorkflowEvent {
+            kind: WorkflowEventKind::Progress,
+            code: "GET_NONCE_START".to_string(),
+            message: "Requesting payment-request nonce from device".to_string(),
+        })
+        .await;
+        let mut workflow = self.workflow.lock().await;
+        let result = get_nonce_for_workflow(&mut workflow).await;
+        drop(workflow);
+
+        match result {
+            Ok(response) => {
+                self.push_event(WorkflowEvent {
+                    kind: WorkflowEventKind::Progress,
+                    code: "GET_NONCE_OK".to_string(),
+                    message: "Payment-request nonce received".to_string(),
+                })
+                .await;
+                Ok(response)
+            }
+            Err(err) => {
+                self.push_error_event(&err).await;
+                Err(err)
+            }
+        }
+    }
+
+    #[uniffi::method]
     pub async fn sign_tx(&self, request: SignTxRequest) -> Result<SignTxResult, HWCoreError> {
         self.push_event(WorkflowEvent {
             kind: WorkflowEventKind::Progress,

--- a/crates/hw-ffi/src/types.rs
+++ b/crates/hw-ffi/src/types.rs
@@ -224,6 +224,7 @@ pub struct GetAddressRequest {
 pub struct AddressResult {
     pub chain: Chain,
     pub address: String,
+    pub mac: Option<String>,
     pub public_key: Option<String>,
 }
 

--- a/crates/hw-wallet/src/btc.rs
+++ b/crates/hw-wallet/src/btc.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 use trezor_connect::thp::{
-    BtcInputScriptType, BtcOutputScriptType, BtcRefTx, BtcRefTxInput, BtcRefTxOutput, BtcSignInput,
-    BtcSignOutput, BtcSignTx, SignTxRequest,
+    BtcInputScriptType, BtcOrigTx, BtcOutputScriptType, BtcPaymentRequest, BtcPaymentRequestAmount,
+    BtcPaymentRequestMemo, BtcRefTx, BtcRefTxInput, BtcRefTxOutput, BtcSignInput, BtcSignOutput,
+    BtcSignTx, SignTxRequest,
 };
 
 use crate::bip32::parse_bip32_path;
@@ -22,6 +23,10 @@ pub struct TxInput {
     pub outputs: Vec<TxInputOutput>,
     #[serde(default)]
     pub ref_txs: Vec<TxInputRefTx>,
+    #[serde(default)]
+    pub orig_txs: Vec<TxInputOrigTx>,
+    #[serde(default)]
+    pub payment_reqs: Vec<TxInputPaymentRequest>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -34,6 +39,10 @@ pub struct TxInputInput {
     pub sequence: u32,
     #[serde(default = "default_input_script_type")]
     pub script_type: String,
+    pub script_sig: Option<String>,
+    pub witness: Option<String>,
+    pub orig_hash: Option<String>,
+    pub orig_index: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -44,6 +53,10 @@ pub struct TxInputOutput {
     #[serde(default = "default_output_script_type")]
     pub script_type: String,
     pub op_return_data: Option<String>,
+    pub orig_hash: Option<String>,
+    pub orig_index: Option<u32>,
+    #[serde(default)]
+    pub payment_req_index: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -75,6 +88,43 @@ pub struct TxInputRefTxOutput {
     pub script_pubkey: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct TxInputOrigTx {
+    pub hash: String,
+    pub version: u32,
+    pub lock_time: u32,
+    pub inputs: Vec<TxInputInput>,
+    pub outputs: Vec<TxInputOutput>,
+    pub extra_data: Option<String>,
+    pub timestamp: Option<u32>,
+    pub version_group_id: Option<u32>,
+    pub expiry: Option<u32>,
+    pub branch_id: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TxInputPaymentRequest {
+    pub nonce: Option<String>,
+    pub recipient_name: String,
+    #[serde(default)]
+    pub memos: Vec<TxInputPaymentRequestMemo>,
+    pub amount: Option<String>,
+    pub signature: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TxInputPaymentRequestMemo {
+    #[serde(rename = "type")]
+    pub memo_type: String,
+    pub title: Option<String>,
+    pub text: Option<String>,
+    pub address: Option<String>,
+    pub path: Option<String>,
+    pub mac: Option<String>,
+    pub coin_type: Option<u32>,
+    pub amount: Option<String>,
+}
+
 fn default_version() -> u32 {
     2
 }
@@ -104,6 +154,8 @@ pub fn build_sign_tx_request(tx: TxInput) -> WalletResult<SignTxRequest> {
         inputs: raw_inputs,
         outputs: raw_outputs,
         ref_txs: raw_ref_txs,
+        orig_txs: raw_orig_txs,
+        payment_reqs: raw_payment_reqs,
     } = tx;
 
     if raw_inputs.is_empty() {
@@ -131,6 +183,14 @@ pub fn build_sign_tx_request(tx: TxInput) -> WalletResult<SignTxRequest> {
                 amount,
                 sequence: input.sequence,
                 script_type,
+                script_sig: input.script_sig.as_deref().map(decode).transpose()?,
+                witness: input.witness.as_deref().map(decode).transpose()?,
+                orig_hash: input
+                    .orig_hash
+                    .as_deref()
+                    .map(|value| parse_hash32("inputs.orig_hash", value))
+                    .transpose()?,
+                orig_index: input.orig_index,
             })
         })
         .collect::<WalletResult<Vec<_>>>()?;
@@ -164,6 +224,13 @@ pub fn build_sign_tx_request(tx: TxInput) -> WalletResult<SignTxRequest> {
                 amount,
                 script_type,
                 op_return_data,
+                orig_hash: output
+                    .orig_hash
+                    .as_deref()
+                    .map(|value| parse_hash32("outputs.orig_hash", value))
+                    .transpose()?,
+                orig_index: output.orig_index,
+                payment_req_index: output.payment_req_index,
             })
         })
         .collect::<WalletResult<Vec<_>>>()?;
@@ -210,7 +277,189 @@ pub fn build_sign_tx_request(tx: TxInput) -> WalletResult<SignTxRequest> {
         })
         .collect::<WalletResult<Vec<_>>>()?;
 
+    let orig_txs = raw_orig_txs
+        .into_iter()
+        .map(|tx| {
+            let hash = parse_hash32("orig_txs.hash", &tx.hash)?;
+            let inputs = tx
+                .inputs
+                .into_iter()
+                .map(|input| {
+                    let path = parse_bip32_path(&input.path)?;
+                    let prev_hash = parse_hash32("orig_txs.inputs.prev_hash", &input.prev_hash)?;
+                    let amount = parse_sats(&input.amount)?;
+                    let script_type = parse_input_script_type(&input.script_type)?;
+                    Ok(BtcSignInput {
+                        path,
+                        prev_hash,
+                        prev_index: input.prev_index,
+                        amount,
+                        sequence: input.sequence,
+                        script_type,
+                        script_sig: input.script_sig.as_deref().map(decode).transpose()?,
+                        witness: input.witness.as_deref().map(decode).transpose()?,
+                        orig_hash: input
+                            .orig_hash
+                            .as_deref()
+                            .map(|value| parse_hash32("orig_txs.inputs.orig_hash", value))
+                            .transpose()?,
+                        orig_index: input.orig_index,
+                    })
+                })
+                .collect::<WalletResult<Vec<_>>>()?;
+            let outputs = tx
+                .outputs
+                .into_iter()
+                .map(|output| {
+                    if output.address.is_none() && output.path.is_none() {
+                        return Err(WalletError::Signing(
+                            "bitcoin original tx output requires either address or path".into(),
+                        ));
+                    }
+                    if output.address.is_some() && output.path.is_some() {
+                        return Err(WalletError::Signing(
+                            "bitcoin original tx output cannot specify both address and path"
+                                .into(),
+                        ));
+                    }
+
+                    let amount = parse_sats(&output.amount)?;
+                    let script_type = parse_output_script_type(&output.script_type)?;
+                    let path = output
+                        .path
+                        .as_deref()
+                        .map(parse_bip32_path)
+                        .transpose()?
+                        .unwrap_or_default();
+                    let op_return_data =
+                        output.op_return_data.as_deref().map(decode).transpose()?;
+                    Ok(BtcSignOutput {
+                        address: output.address,
+                        path,
+                        amount,
+                        script_type,
+                        op_return_data,
+                        orig_hash: output
+                            .orig_hash
+                            .as_deref()
+                            .map(|value| parse_hash32("orig_txs.outputs.orig_hash", value))
+                            .transpose()?,
+                        orig_index: output.orig_index,
+                        payment_req_index: output.payment_req_index,
+                    })
+                })
+                .collect::<WalletResult<Vec<_>>>()?;
+            let extra_data = tx.extra_data.as_deref().map(decode).transpose()?;
+            Ok(BtcOrigTx {
+                hash,
+                version: tx.version,
+                lock_time: tx.lock_time,
+                inputs,
+                outputs,
+                extra_data,
+                timestamp: tx.timestamp,
+                version_group_id: tx.version_group_id,
+                expiry: tx.expiry,
+                branch_id: tx.branch_id,
+            })
+        })
+        .collect::<WalletResult<Vec<_>>>()?;
+
+    let payment_reqs = raw_payment_reqs
+        .into_iter()
+        .map(|payment_req| {
+            let memos = payment_req
+                .memos
+                .into_iter()
+                .map(|memo| match memo.memo_type.as_str() {
+                    "text" => Ok(BtcPaymentRequestMemo::Text {
+                        text: memo.text.ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request text memo requires text".into(),
+                            )
+                        })?,
+                    }),
+                    "text_details" => Ok(BtcPaymentRequestMemo::TextDetails {
+                        title: memo.title.ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request text_details memo requires title".into(),
+                            )
+                        })?,
+                        text: memo.text.ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request text_details memo requires text".into(),
+                            )
+                        })?,
+                    }),
+                    "refund" => Ok(BtcPaymentRequestMemo::Refund {
+                        address: memo.address.ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request refund memo requires address".into(),
+                            )
+                        })?,
+                        path: parse_bip32_path(memo.path.as_deref().ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request refund memo requires path".into(),
+                            )
+                        })?)?,
+                        mac: decode(memo.mac.as_deref().ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request refund memo requires mac".into(),
+                            )
+                        })?)?,
+                    }),
+                    "coin_purchase" => Ok(BtcPaymentRequestMemo::CoinPurchase {
+                        coin_type: memo.coin_type.ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request coin_purchase memo requires coin_type"
+                                    .into(),
+                            )
+                        })?,
+                        amount: memo.amount.ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request coin_purchase memo requires amount".into(),
+                            )
+                        })?,
+                        address: memo.address.ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request coin_purchase memo requires address"
+                                    .into(),
+                            )
+                        })?,
+                        path: parse_bip32_path(memo.path.as_deref().ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request coin_purchase memo requires path".into(),
+                            )
+                        })?)?,
+                        mac: decode(memo.mac.as_deref().ok_or_else(|| {
+                            WalletError::Signing(
+                                "bitcoin payment request coin_purchase memo requires mac".into(),
+                            )
+                        })?)?,
+                    }),
+                    other => Err(WalletError::Signing(format!(
+                        "unsupported bitcoin payment request memo type '{other}'"
+                    ))),
+                })
+                .collect::<WalletResult<Vec<_>>>()?;
+
+            Ok(BtcPaymentRequest {
+                nonce: payment_req.nonce.as_deref().map(decode).transpose()?,
+                recipient_name: payment_req.recipient_name,
+                memos,
+                amount: payment_req
+                    .amount
+                    .as_deref()
+                    .map(parse_sats)
+                    .transpose()?
+                    .map(BtcPaymentRequestAmount::from_sats),
+                signature: decode(&payment_req.signature)?,
+            })
+        })
+        .collect::<WalletResult<Vec<_>>>()?;
+
     validate_ref_txs_for_inputs(&inputs, &ref_txs)?;
+    validate_original_tx_links(&inputs, &outputs, &orig_txs)?;
 
     Ok(SignTxRequest::bitcoin(BtcSignTx {
         version,
@@ -218,6 +467,8 @@ pub fn build_sign_tx_request(tx: TxInput) -> WalletResult<SignTxRequest> {
         inputs,
         outputs,
         ref_txs,
+        orig_txs,
+        payment_reqs,
         chunkify,
     }))
 }
@@ -263,6 +514,75 @@ fn validate_ref_txs_for_inputs(inputs: &[BtcSignInput], ref_txs: &[BtcRefTx]) ->
                 ::hex::encode(&input.prev_hash),
                 ref_tx.bin_outputs.len()
             )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_original_tx_links(
+    inputs: &[BtcSignInput],
+    outputs: &[BtcSignOutput],
+    orig_txs: &[BtcOrigTx],
+) -> WalletResult<()> {
+    let mut orig_txs_by_hash: HashMap<Vec<u8>, &BtcOrigTx> = HashMap::new();
+    for orig_tx in orig_txs {
+        if orig_txs_by_hash
+            .insert(orig_tx.hash.clone(), orig_tx)
+            .is_some()
+        {
+            return Err(WalletError::Signing(format!(
+                "duplicate original transaction hash {}",
+                hex::encode(&orig_tx.hash)
+            )));
+        }
+    }
+
+    for (index, input) in inputs.iter().enumerate() {
+        if input.orig_hash.is_some() != input.orig_index.is_some() {
+            return Err(WalletError::Signing(format!(
+                "inputs[{index}] must specify both orig_hash and orig_index"
+            )));
+        }
+        if let (Some(orig_hash), Some(orig_index)) = (&input.orig_hash, input.orig_index) {
+            let orig_tx = orig_txs_by_hash.get(orig_hash).ok_or_else(|| {
+                WalletError::Signing(format!(
+                    "missing original transaction {} for inputs[{index}]",
+                    hex::encode(orig_hash)
+                ))
+            })?;
+            if usize::try_from(orig_index)
+                .ok()
+                .is_none_or(|idx| idx >= orig_tx.inputs.len())
+            {
+                return Err(WalletError::Signing(format!(
+                    "orig_index {orig_index} out of bounds for inputs[{index}]"
+                )));
+            }
+        }
+    }
+
+    for (index, output) in outputs.iter().enumerate() {
+        if output.orig_hash.is_some() != output.orig_index.is_some() {
+            return Err(WalletError::Signing(format!(
+                "outputs[{index}] must specify both orig_hash and orig_index"
+            )));
+        }
+        if let (Some(orig_hash), Some(orig_index)) = (&output.orig_hash, output.orig_index) {
+            let orig_tx = orig_txs_by_hash.get(orig_hash).ok_or_else(|| {
+                WalletError::Signing(format!(
+                    "missing original transaction {} for outputs[{index}]",
+                    hex::encode(orig_hash)
+                ))
+            })?;
+            if usize::try_from(orig_index)
+                .ok()
+                .is_none_or(|idx| idx >= orig_tx.outputs.len())
+            {
+                return Err(WalletError::Signing(format!(
+                    "orig_index {orig_index} out of bounds for outputs[{index}]"
+                )));
+            }
         }
     }
 
@@ -324,6 +644,8 @@ mod tests {
         include_str!("../../../tests/data/bitcoin/btc_missing_ref_txs.json");
     const BTC_PREV_INDEX_OOB: &str =
         include_str!("../../../tests/data/bitcoin/btc_prev_index_oob.json");
+    const BTC_RBF_WITH_PAYMENT_REQ: &str =
+        include_str!("../../../tests/data/bitcoin/btc_rbf_with_payment_req.json");
 
     #[test]
     fn parse_btc_tx_json() {
@@ -343,6 +665,20 @@ mod tests {
         assert_eq!(btc.inputs[0].amount, 100);
         assert_eq!(btc.outputs[0].amount, 90);
         assert_eq!(btc.ref_txs.len(), 1);
+    }
+
+    #[test]
+    fn build_btc_sign_request_with_orig_txs_and_payment_reqs() {
+        let tx = parse_tx_json(BTC_RBF_WITH_PAYMENT_REQ).unwrap();
+        let request = build_sign_tx_request(tx).unwrap();
+        let btc = request.btc.unwrap();
+        assert_eq!(btc.orig_txs.len(), 1);
+        assert_eq!(btc.payment_reqs.len(), 1);
+        assert_eq!(
+            btc.inputs[0].orig_hash.as_deref(),
+            Some([0x11; 32].as_slice())
+        );
+        assert_eq!(btc.outputs[0].payment_req_index, Some(0));
     }
 
     #[test]

--- a/crates/trezor-connect/src/ble.rs
+++ b/crates/trezor-connect/src/ble.rs
@@ -28,14 +28,16 @@ use crate::thp::proto::{
     EncodedMessage, MESSAGE_TYPE_BITCOIN_TX_REQUEST, MESSAGE_TYPE_ETHEREUM_TX_REQUEST,
     MESSAGE_TYPE_SOLANA_TX_SIGNATURE, ProtoMappingError, decode_bitcoin_tx_request,
     decode_code_entry_cpace_response, decode_credential_response, decode_get_address_response,
-    decode_get_public_key_response, decode_pairing_request_approved, decode_select_method_response,
-    decode_sign_message_response, decode_sign_typed_data_message, decode_sign_typed_data_response,
-    decode_solana_tx_signature, decode_tag_response, decode_tx_request,
-    encode_bitcoin_tx_ack_input, encode_bitcoin_tx_ack_meta, encode_bitcoin_tx_ack_output,
-    encode_bitcoin_tx_ack_prev_extra_data, encode_bitcoin_tx_ack_prev_input,
-    encode_bitcoin_tx_ack_prev_meta, encode_bitcoin_tx_ack_prev_output,
-    encode_code_entry_challenge, encode_code_entry_tag, encode_credential_request,
-    encode_end_request, encode_get_address_request, encode_get_public_key_request, encode_nfc_tag,
+    decode_get_nonce_response, decode_get_public_key_response, decode_pairing_request_approved,
+    decode_select_method_response, decode_sign_message_response, decode_sign_typed_data_message,
+    decode_sign_typed_data_response, decode_solana_tx_signature, decode_tag_response,
+    decode_tx_request, encode_bitcoin_tx_ack_input, encode_bitcoin_tx_ack_meta,
+    encode_bitcoin_tx_ack_orig_meta, encode_bitcoin_tx_ack_output,
+    encode_bitcoin_tx_ack_payment_request, encode_bitcoin_tx_ack_prev_extra_data,
+    encode_bitcoin_tx_ack_prev_input, encode_bitcoin_tx_ack_prev_meta,
+    encode_bitcoin_tx_ack_prev_output, encode_code_entry_challenge, encode_code_entry_tag,
+    encode_credential_request, encode_end_request, encode_get_address_request,
+    encode_get_nonce_request, encode_get_public_key_request, encode_nfc_tag,
     encode_pairing_request, encode_qr_tag, encode_select_method, encode_sign_message_request,
     encode_sign_tx_request, encode_sign_typed_data_request, encode_tx_ack,
     encode_typed_data_struct_ack, encode_typed_data_value_ack,
@@ -156,6 +158,7 @@ fn decode_failure_as_backend_error(payload: &[u8]) -> BackendError {
     }
 }
 
+#[derive(Debug)]
 enum BitcoinTxRequestHandling {
     Ack(EncodedMessage),
     Finished,
@@ -180,6 +183,15 @@ fn build_ref_txs_index(
         .collect()
 }
 
+fn build_orig_txs_index(
+    btc: &crate::thp::types::BtcSignTx,
+) -> HashMap<&[u8], &crate::thp::types::BtcOrigTx> {
+    btc.orig_txs
+        .iter()
+        .map(|tx| (tx.hash.as_slice(), tx))
+        .collect()
+}
+
 fn find_ref_tx<'a>(
     ref_txs_by_hash: &'a HashMap<&'a [u8], &'a crate::thp::types::BtcRefTx>,
     tx_hash: &[u8],
@@ -193,9 +205,23 @@ fn find_ref_tx<'a>(
     })
 }
 
+fn find_orig_tx<'a>(
+    orig_txs_by_hash: &'a HashMap<&'a [u8], &'a crate::thp::types::BtcOrigTx>,
+    tx_hash: &[u8],
+    request_name: &str,
+) -> BackendResult<&'a crate::thp::types::BtcOrigTx> {
+    orig_txs_by_hash.get(tx_hash).copied().ok_or_else(|| {
+        BackendError::Transport(format!(
+            "{request_name} request references unknown original transaction hash {}",
+            hex::encode(tx_hash)
+        ))
+    })
+}
+
 fn handle_bitcoin_tx_request(
     btc: &crate::thp::types::BtcSignTx,
     ref_txs_by_hash: &HashMap<&[u8], &crate::thp::types::BtcRefTx>,
+    orig_txs_by_hash: &HashMap<&[u8], &crate::thp::types::BtcOrigTx>,
     tx_request: &DecodedBitcoinTxRequest,
 ) -> BackendResult<BitcoinTxRequestHandling> {
     match tx_request.request_type {
@@ -253,8 +279,12 @@ fn handle_bitcoin_tx_request(
         }
         Some(BitcoinTxRequestType::TxMeta) => {
             let ack = if let Some(ref_tx_hash) = tx_request.tx_hash.as_ref() {
-                let ref_tx = find_ref_tx(ref_txs_by_hash, ref_tx_hash, "TxMeta")?;
-                encode_bitcoin_tx_ack_prev_meta(ref_tx)
+                if let Some(orig_tx) = orig_txs_by_hash.get(ref_tx_hash.as_slice()).copied() {
+                    encode_bitcoin_tx_ack_orig_meta(orig_tx)
+                } else {
+                    let ref_tx = find_ref_tx(ref_txs_by_hash, ref_tx_hash, "TxMeta")?;
+                    encode_bitcoin_tx_ack_prev_meta(ref_tx)
+                }
             } else {
                 encode_bitcoin_tx_ack_meta(
                     btc.version,
@@ -272,19 +302,25 @@ fn handle_bitcoin_tx_request(
                     "TxExtraData request missing tx_hash for previous transaction".into(),
                 )
             })?;
-            let ref_tx = find_ref_tx(ref_txs_by_hash, ref_tx_hash, "TxExtraData")?;
             let extra_data_len = tx_request.extra_data_len.ok_or_else(|| {
                 BackendError::Transport("TxExtraData request missing extra_data_len".into())
             })? as usize;
             let extra_data_offset = tx_request.extra_data_offset.ok_or_else(|| {
                 BackendError::Transport("TxExtraData request missing extra_data_offset".into())
             })? as usize;
-            let extra_data = ref_tx.extra_data.as_deref().ok_or_else(|| {
-                BackendError::Transport(format!(
-                    "TxExtraData requested for previous transaction {} without extra_data",
-                    hex::encode(ref_tx_hash)
-                ))
-            })?;
+            let extra_data =
+                if let Some(orig_tx) = orig_txs_by_hash.get(ref_tx_hash.as_slice()).copied() {
+                    orig_tx.extra_data.as_deref()
+                } else {
+                    let ref_tx = find_ref_tx(ref_txs_by_hash, ref_tx_hash, "TxExtraData")?;
+                    ref_tx.extra_data.as_deref()
+                }
+                .ok_or_else(|| {
+                    BackendError::Transport(format!(
+                        "TxExtraData requested for transaction {} without extra_data",
+                        hex::encode(ref_tx_hash)
+                    ))
+                })?;
             let end = extra_data_offset
                 .checked_add(extra_data_len)
                 .ok_or_else(|| {
@@ -304,11 +340,53 @@ fn handle_bitcoin_tx_request(
             Ok(BitcoinTxRequestHandling::Ack(ack))
         }
         Some(BitcoinTxRequestType::TxFinished) => Ok(BitcoinTxRequestHandling::Finished),
-        Some(BitcoinTxRequestType::TxOrigInput)
-        | Some(BitcoinTxRequestType::TxOrigOutput)
-        | Some(BitcoinTxRequestType::TxPaymentReq) => Err(BackendError::Transport(
-            "Bitcoin request type is not implemented yet for this flow; only TXMETA/TXINPUT/TXOUTPUT/TXEXTRADATA are supported for previous transactions in v1".into(),
-        )),
+        Some(BitcoinTxRequestType::TxOrigInput) => {
+            let orig_tx_hash = tx_request.tx_hash.as_ref().ok_or_else(|| {
+                BackendError::Transport("TxOrigInput request missing tx_hash".into())
+            })?;
+            let orig_tx = find_orig_tx(orig_txs_by_hash, orig_tx_hash, "TxOrigInput")?;
+            let index = request_index(tx_request, "TxOrigInput")?;
+            let input = orig_tx.inputs.get(index).ok_or_else(|| {
+                BackendError::Transport(format!(
+                    "TxOrigInput request index {} out of bounds for original transaction {} (inputs={})",
+                    index,
+                    hex::encode(orig_tx_hash),
+                    orig_tx.inputs.len()
+                ))
+            })?;
+            let ack = encode_bitcoin_tx_ack_input(input).map_err(BleBackend::transport_error)?;
+            Ok(BitcoinTxRequestHandling::Ack(ack))
+        }
+        Some(BitcoinTxRequestType::TxOrigOutput) => {
+            let orig_tx_hash = tx_request.tx_hash.as_ref().ok_or_else(|| {
+                BackendError::Transport("TxOrigOutput request missing tx_hash".into())
+            })?;
+            let orig_tx = find_orig_tx(orig_txs_by_hash, orig_tx_hash, "TxOrigOutput")?;
+            let index = request_index(tx_request, "TxOrigOutput")?;
+            let output = orig_tx.outputs.get(index).ok_or_else(|| {
+                BackendError::Transport(format!(
+                    "TxOrigOutput request index {} out of bounds for original transaction {} (outputs={})",
+                    index,
+                    hex::encode(orig_tx_hash),
+                    orig_tx.outputs.len()
+                ))
+            })?;
+            let ack = encode_bitcoin_tx_ack_output(output).map_err(BleBackend::transport_error)?;
+            Ok(BitcoinTxRequestHandling::Ack(ack))
+        }
+        Some(BitcoinTxRequestType::TxPaymentReq) => {
+            let index = request_index(tx_request, "TxPaymentReq")?;
+            let pr = btc.payment_reqs.get(index).ok_or_else(|| {
+                BackendError::Transport(format!(
+                    "TxPaymentReq request index {} out of bounds (payment_reqs={})",
+                    index,
+                    btc.payment_reqs.len()
+                ))
+            })?;
+            let ack =
+                encode_bitcoin_tx_ack_payment_request(pr).map_err(BleBackend::transport_error)?;
+            Ok(BitcoinTxRequestHandling::Ack(ack))
+        }
         None => Ok(BitcoinTxRequestHandling::Continue),
     }
 }

--- a/crates/trezor-connect/src/ble/backend_impl.rs
+++ b/crates/trezor-connect/src/ble/backend_impl.rs
@@ -562,6 +562,27 @@ impl ThpBackend for BleBackend {
         Ok(response)
     }
 
+    async fn get_nonce(&mut self) -> BackendResult<Vec<u8>> {
+        let encoded = encode_get_nonce_request().map_err(Self::transport_error)?;
+        self.send_encrypted_request(encoded).await?;
+
+        let parsed = self.read_next().await?;
+        let response_or_reason: ResponseOrReason<Vec<u8>> = self
+            .parse_encrypted_response(parsed, |message_type, payload| {
+                if message_type == MESSAGE_TYPE_FAILURE {
+                    return Ok(Err(decode_failure_as_backend_error(payload)));
+                }
+                let response = decode_get_nonce_response(message_type, payload)?;
+                Ok(Ok(response))
+            })
+            .await?;
+
+        match response_or_reason {
+            Ok(response) => Ok(response),
+            Err(err) => Err(err),
+        }
+    }
+
     async fn sign_message(
         &mut self,
         request: SignMessageRequest,
@@ -720,6 +741,7 @@ impl ThpBackend for BleBackend {
                     BackendError::Transport("missing Bitcoin signing payload".into())
                 })?;
                 let ref_txs_by_hash = build_ref_txs_index(&btc);
+                let orig_txs_by_hash = build_orig_txs_index(&btc);
                 let mut latest_signature: Option<Vec<u8>> = None;
 
                 loop {
@@ -738,7 +760,12 @@ impl ThpBackend for BleBackend {
                         latest_signature = Some(signature.clone());
                     }
 
-                    match handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &tx_request)? {
+                    match handle_bitcoin_tx_request(
+                        &btc,
+                        &ref_txs_by_hash,
+                        &orig_txs_by_hash,
+                        &tx_request,
+                    )? {
                         BitcoinTxRequestHandling::Ack(ack) => {
                             self.send_encrypted_request(ack).await?;
                         }

--- a/crates/trezor-connect/src/ble/tests.rs
+++ b/crates/trezor-connect/src/ble/tests.rs
@@ -11,6 +11,10 @@ fn sample_btc_sign_tx() -> crate::thp::types::BtcSignTx {
             amount: 1000,
             sequence: 0xffff_ffff,
             script_type: crate::thp::types::BtcInputScriptType::SpendWitness,
+            script_sig: None,
+            witness: None,
+            orig_hash: Some(vec![0x33; 32]),
+            orig_index: Some(0),
         }],
         outputs: vec![crate::thp::types::BtcSignOutput {
             address: Some("bc1qtest".to_string()),
@@ -18,6 +22,9 @@ fn sample_btc_sign_tx() -> crate::thp::types::BtcSignTx {
             amount: 900,
             script_type: crate::thp::types::BtcOutputScriptType::PayToAddress,
             op_return_data: None,
+            orig_hash: Some(vec![0x33; 32]),
+            orig_index: Some(0),
+            payment_req_index: Some(0),
         }],
         ref_txs: vec![crate::thp::types::BtcRefTx {
             hash: vec![0x11; 32],
@@ -39,6 +46,39 @@ fn sample_btc_sign_tx() -> crate::thp::types::BtcSignTx {
             expiry: None,
             branch_id: None,
         }],
+        orig_txs: vec![crate::thp::types::BtcOrigTx {
+            hash: vec![0x33; 32],
+            version: 2,
+            lock_time: 0,
+            inputs: vec![crate::thp::types::BtcSignInput {
+                path: vec![0x8000_0054, 0x8000_0000, 0x8000_0000, 0, 0],
+                prev_hash: vec![0x44; 32],
+                prev_index: 0,
+                amount: 1000,
+                sequence: 0xffff_fffe,
+                script_type: crate::thp::types::BtcInputScriptType::SpendWitness,
+                script_sig: Some(vec![0xaa]),
+                witness: Some(vec![0xbb]),
+                orig_hash: None,
+                orig_index: None,
+            }],
+            outputs: vec![crate::thp::types::BtcSignOutput {
+                address: Some("bc1qorig".to_string()),
+                path: Vec::new(),
+                amount: 900,
+                script_type: crate::thp::types::BtcOutputScriptType::PayToAddress,
+                op_return_data: None,
+                orig_hash: None,
+                orig_index: None,
+                payment_req_index: None,
+            }],
+            extra_data: None,
+            timestamp: None,
+            version_group_id: None,
+            expiry: None,
+            branch_id: None,
+        }],
+        payment_reqs: Vec::new(),
         chunkify: false,
     }
 }
@@ -47,6 +87,7 @@ fn sample_btc_sign_tx() -> crate::thp::types::BtcSignTx {
 fn handles_prev_meta_request() {
     let btc = sample_btc_sign_tx();
     let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
     let tx_request = DecodedBitcoinTxRequest {
         request_type: Some(BitcoinTxRequestType::TxMeta),
         request_index: None,
@@ -58,7 +99,8 @@ fn handles_prev_meta_request() {
         serialized_tx: None,
     };
 
-    let result = handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &tx_request).unwrap();
+    let result =
+        handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request).unwrap();
     let BitcoinTxRequestHandling::Ack(ack) = result else {
         panic!("expected ack");
     };
@@ -72,6 +114,7 @@ fn handles_prev_meta_request() {
 fn prev_input_unknown_hash_is_error() {
     let btc = sample_btc_sign_tx();
     let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
     let tx_request = DecodedBitcoinTxRequest {
         request_type: Some(BitcoinTxRequestType::TxInput),
         request_index: Some(0),
@@ -83,10 +126,11 @@ fn prev_input_unknown_hash_is_error() {
         serialized_tx: None,
     };
 
-    let err = match handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &tx_request) {
-        Ok(_) => panic!("expected error"),
-        Err(err) => err,
-    };
+    let err =
+        match handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request) {
+            Ok(_) => panic!("expected error"),
+            Err(err) => err,
+        };
     assert!(
         err.to_string()
             .contains("TxInput request references unknown previous transaction hash")
@@ -97,6 +141,7 @@ fn prev_input_unknown_hash_is_error() {
 fn prev_output_out_of_bounds_is_error() {
     let btc = sample_btc_sign_tx();
     let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
     let tx_request = DecodedBitcoinTxRequest {
         request_type: Some(BitcoinTxRequestType::TxOutput),
         request_index: Some(2),
@@ -108,10 +153,11 @@ fn prev_output_out_of_bounds_is_error() {
         serialized_tx: None,
     };
 
-    let err = match handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &tx_request) {
-        Ok(_) => panic!("expected error"),
-        Err(err) => err,
-    };
+    let err =
+        match handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request) {
+            Ok(_) => panic!("expected error"),
+            Err(err) => err,
+        };
     assert!(
         err.to_string()
             .contains("TxOutput request index 2 out of bounds for previous transaction")
@@ -134,6 +180,192 @@ fn thp_v2_chunk_reassembly_roundtrip() {
 
     assert!(pending.is_none(), "reassembly should complete");
     assert_eq!(reassembled.as_deref(), Some(frame.as_slice()));
+}
+
+#[test]
+fn handles_tx_orig_input_request() {
+    let btc = sample_btc_sign_tx();
+    let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
+    let tx_request = DecodedBitcoinTxRequest {
+        request_type: Some(BitcoinTxRequestType::TxOrigInput),
+        request_index: Some(0),
+        tx_hash: Some(vec![0x33; 32]),
+        extra_data_len: None,
+        extra_data_offset: None,
+        signature_index: None,
+        signature: None,
+        serialized_tx: None,
+    };
+
+    let result =
+        handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request).unwrap();
+    let BitcoinTxRequestHandling::Ack(ack) = result else {
+        panic!("expected ack");
+    };
+    assert_eq!(
+        ack.message_type,
+        crate::thp::proto::MESSAGE_TYPE_BITCOIN_TX_ACK
+    );
+}
+
+#[test]
+fn handles_tx_orig_output_request() {
+    let btc = sample_btc_sign_tx();
+    let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
+    let tx_request = DecodedBitcoinTxRequest {
+        request_type: Some(BitcoinTxRequestType::TxOrigOutput),
+        request_index: Some(0),
+        tx_hash: Some(vec![0x33; 32]),
+        extra_data_len: None,
+        extra_data_offset: None,
+        signature_index: None,
+        signature: None,
+        serialized_tx: None,
+    };
+
+    let result =
+        handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request).unwrap();
+    let BitcoinTxRequestHandling::Ack(ack) = result else {
+        panic!("expected ack");
+    };
+    assert_eq!(
+        ack.message_type,
+        crate::thp::proto::MESSAGE_TYPE_BITCOIN_TX_ACK
+    );
+}
+
+#[test]
+fn tx_orig_input_out_of_bounds_is_error() {
+    let btc = sample_btc_sign_tx();
+    let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
+    let tx_request = DecodedBitcoinTxRequest {
+        request_type: Some(BitcoinTxRequestType::TxOrigInput),
+        request_index: Some(99),
+        tx_hash: Some(vec![0x33; 32]),
+        extra_data_len: None,
+        extra_data_offset: None,
+        signature_index: None,
+        signature: None,
+        serialized_tx: None,
+    };
+
+    let err = handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request)
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("TxOrigInput request index 99 out of bounds"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn tx_orig_output_out_of_bounds_is_error() {
+    let btc = sample_btc_sign_tx();
+    let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
+    let tx_request = DecodedBitcoinTxRequest {
+        request_type: Some(BitcoinTxRequestType::TxOrigOutput),
+        request_index: Some(99),
+        tx_hash: Some(vec![0x33; 32]),
+        extra_data_len: None,
+        extra_data_offset: None,
+        signature_index: None,
+        signature: None,
+        serialized_tx: None,
+    };
+
+    let err = handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request)
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("TxOrigOutput request index 99 out of bounds"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn handles_tx_payment_req_request() {
+    use crate::thp::types::{BtcPaymentRequest, BtcPaymentRequestAmount, BtcPaymentRequestMemo};
+
+    let mut btc = sample_btc_sign_tx();
+    btc.payment_reqs = vec![BtcPaymentRequest {
+        nonce: Some(vec![0x01, 0x02, 0x03]),
+        recipient_name: "Test Merchant".to_string(),
+        memos: vec![
+            BtcPaymentRequestMemo::Text {
+                text: "Invoice #42".to_string(),
+            },
+            BtcPaymentRequestMemo::TextDetails {
+                title: "Details".to_string(),
+                text: "Extra context".to_string(),
+            },
+            BtcPaymentRequestMemo::Refund {
+                address: "tb1qrefund".to_string(),
+                path: vec![0x8000_0001, 0x8000_0000, 0x8000_0000, 1, 0],
+                mac: vec![0xaa, 0xbb],
+            },
+            BtcPaymentRequestMemo::CoinPurchase {
+                coin_type: 1,
+                amount: "0.025 BTC".to_string(),
+                address: "tb1qcoinpurchase".to_string(),
+                path: vec![0x8000_0001, 0x8000_0000, 0x8000_0000, 1, 1],
+                mac: vec![0xcc, 0xdd],
+            },
+        ],
+        amount: Some(BtcPaymentRequestAmount::from_sats(900)),
+        signature: vec![0xde, 0xad],
+    }];
+
+    let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
+    let tx_request = DecodedBitcoinTxRequest {
+        request_type: Some(BitcoinTxRequestType::TxPaymentReq),
+        request_index: Some(0),
+        tx_hash: None,
+        extra_data_len: None,
+        extra_data_offset: None,
+        signature_index: None,
+        signature: None,
+        serialized_tx: None,
+    };
+
+    let result =
+        handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request).unwrap();
+    let BitcoinTxRequestHandling::Ack(ack) = result else {
+        panic!("expected ack");
+    };
+    assert_eq!(
+        ack.message_type,
+        crate::thp::proto::MESSAGE_TYPE_BITCOIN_TX_ACK_PAYMENT_REQUEST
+    );
+}
+
+#[test]
+fn tx_payment_req_missing_entry_is_error() {
+    let btc = sample_btc_sign_tx();
+    let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
+    let tx_request = DecodedBitcoinTxRequest {
+        request_type: Some(BitcoinTxRequestType::TxPaymentReq),
+        request_index: Some(0),
+        tx_hash: None,
+        extra_data_len: None,
+        extra_data_offset: None,
+        signature_index: None,
+        signature: None,
+        serialized_tx: None,
+    };
+
+    let err = handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request)
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("TxPaymentReq request index 0 out of bounds"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]
@@ -163,4 +395,309 @@ fn thp_v2_chunk_reassembly_recovers_after_bad_continuation() {
 
     assert!(pending.is_none(), "reassembly should complete");
     assert_eq!(reassembled.as_deref(), Some(frame2.as_slice()));
+}
+
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    if stripped.is_empty() {
+        return Vec::new();
+    }
+    hex::decode(stripped).expect("invalid hex in fixture")
+}
+
+fn load_rbf_fixture() -> crate::thp::types::BtcSignTx {
+    let json: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../../tests/data/bitcoin/btc_rbf_with_payment_req.json"
+    ))
+    .expect("fixture is valid JSON");
+
+    let parse_path = |s: &str| -> Vec<u32> {
+        s.strip_prefix("m/")
+            .unwrap_or(s)
+            .split('/')
+            .map(|component| {
+                if let Some(stripped) = component.strip_suffix('\'') {
+                    stripped.parse::<u32>().unwrap() | 0x8000_0000
+                } else {
+                    component.parse::<u32>().unwrap()
+                }
+            })
+            .collect()
+    };
+
+    let inputs: Vec<crate::thp::types::BtcSignInput> = json["inputs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|inp| crate::thp::types::BtcSignInput {
+            path: parse_path(inp["path"].as_str().unwrap()),
+            prev_hash: hex_to_bytes(inp["prev_hash"].as_str().unwrap()),
+            prev_index: inp["prev_index"].as_u64().unwrap() as u32,
+            amount: inp["amount"].as_str().unwrap().parse().unwrap(),
+            sequence: inp["sequence"].as_u64().unwrap_or(0xffff_ffff) as u32,
+            script_type: match inp["script_type"].as_str().unwrap_or("spendwitness") {
+                "spendwitness" => crate::thp::types::BtcInputScriptType::SpendWitness,
+                "spendaddress" => crate::thp::types::BtcInputScriptType::SpendAddress,
+                "spendtaproot" => crate::thp::types::BtcInputScriptType::SpendTaproot,
+                other => panic!("unsupported script_type: {other}"),
+            },
+            script_sig: inp["script_sig"].as_str().map(hex_to_bytes),
+            witness: inp["witness"].as_str().map(hex_to_bytes),
+            orig_hash: inp["orig_hash"].as_str().map(hex_to_bytes),
+            orig_index: inp["orig_index"].as_u64().map(|index| index as u32),
+        })
+        .collect();
+
+    let outputs: Vec<crate::thp::types::BtcSignOutput> = json["outputs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|out| crate::thp::types::BtcSignOutput {
+            address: out["address"].as_str().map(String::from),
+            path: out["path"].as_str().map(parse_path).unwrap_or_default(),
+            amount: out["amount"].as_str().unwrap().parse().unwrap(),
+            script_type: match out["script_type"].as_str().unwrap_or("paytoaddress") {
+                "paytowitness" => crate::thp::types::BtcOutputScriptType::PayToWitness,
+                "paytoaddress" => crate::thp::types::BtcOutputScriptType::PayToAddress,
+                "paytotaproot" => crate::thp::types::BtcOutputScriptType::PayToTaproot,
+                other => panic!("unsupported output script_type: {other}"),
+            },
+            op_return_data: None,
+            orig_hash: out["orig_hash"].as_str().map(hex_to_bytes),
+            orig_index: out["orig_index"].as_u64().map(|index| index as u32),
+            payment_req_index: out["payment_req_index"].as_u64().map(|index| index as u32),
+        })
+        .collect();
+
+    let ref_txs: Vec<crate::thp::types::BtcRefTx> = json["ref_txs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|rtx| crate::thp::types::BtcRefTx {
+            hash: hex_to_bytes(rtx["hash"].as_str().unwrap()),
+            version: rtx["version"].as_u64().unwrap() as u32,
+            lock_time: rtx["lock_time"].as_u64().unwrap() as u32,
+            inputs: rtx["inputs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|ri| crate::thp::types::BtcRefTxInput {
+                    prev_hash: hex_to_bytes(ri["prev_hash"].as_str().unwrap()),
+                    prev_index: ri["prev_index"].as_u64().unwrap() as u32,
+                    script_sig: hex_to_bytes(ri["script_sig"].as_str().unwrap()),
+                    sequence: ri["sequence"].as_u64().unwrap_or(0xffff_ffff) as u32,
+                })
+                .collect(),
+            bin_outputs: rtx["bin_outputs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|bo| crate::thp::types::BtcRefTxOutput {
+                    amount: bo["amount"].as_str().unwrap().parse().unwrap(),
+                    script_pubkey: hex_to_bytes(bo["script_pubkey"].as_str().unwrap()),
+                })
+                .collect(),
+            extra_data: None,
+            timestamp: None,
+            version_group_id: None,
+            expiry: None,
+            branch_id: None,
+        })
+        .collect();
+
+    let orig_txs: Vec<crate::thp::types::BtcOrigTx> = json["orig_txs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|otx| crate::thp::types::BtcOrigTx {
+            hash: hex_to_bytes(otx["hash"].as_str().unwrap()),
+            version: otx["version"].as_u64().unwrap() as u32,
+            lock_time: otx["lock_time"].as_u64().unwrap() as u32,
+            inputs: otx["inputs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|inp| crate::thp::types::BtcSignInput {
+                    path: parse_path(inp["path"].as_str().unwrap()),
+                    prev_hash: hex_to_bytes(inp["prev_hash"].as_str().unwrap()),
+                    prev_index: inp["prev_index"].as_u64().unwrap() as u32,
+                    amount: inp["amount"].as_str().unwrap().parse().unwrap(),
+                    sequence: inp["sequence"].as_u64().unwrap_or(0xffff_ffff) as u32,
+                    script_type: match inp["script_type"].as_str().unwrap_or("spendwitness") {
+                        "spendwitness" => crate::thp::types::BtcInputScriptType::SpendWitness,
+                        "spendaddress" => crate::thp::types::BtcInputScriptType::SpendAddress,
+                        "spendtaproot" => crate::thp::types::BtcInputScriptType::SpendTaproot,
+                        other => panic!("unsupported script_type: {other}"),
+                    },
+                    script_sig: inp["script_sig"].as_str().map(hex_to_bytes),
+                    witness: inp["witness"].as_str().map(hex_to_bytes),
+                    orig_hash: inp["orig_hash"].as_str().map(hex_to_bytes),
+                    orig_index: inp["orig_index"].as_u64().map(|index| index as u32),
+                })
+                .collect(),
+            outputs: otx["outputs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|out| crate::thp::types::BtcSignOutput {
+                    address: out["address"].as_str().map(String::from),
+                    path: out["path"].as_str().map(parse_path).unwrap_or_default(),
+                    amount: out["amount"].as_str().unwrap().parse().unwrap(),
+                    script_type: match out["script_type"].as_str().unwrap_or("paytoaddress") {
+                        "paytowitness" => crate::thp::types::BtcOutputScriptType::PayToWitness,
+                        "paytoaddress" => crate::thp::types::BtcOutputScriptType::PayToAddress,
+                        "paytotaproot" => crate::thp::types::BtcOutputScriptType::PayToTaproot,
+                        other => panic!("unsupported output script_type: {other}"),
+                    },
+                    op_return_data: out["op_return_data"].as_str().map(hex_to_bytes),
+                    orig_hash: out["orig_hash"].as_str().map(hex_to_bytes),
+                    orig_index: out["orig_index"].as_u64().map(|index| index as u32),
+                    payment_req_index: out["payment_req_index"].as_u64().map(|index| index as u32),
+                })
+                .collect(),
+            extra_data: otx["extra_data"].as_str().map(hex_to_bytes),
+            timestamp: otx["timestamp"].as_u64().map(|value| value as u32),
+            version_group_id: otx["version_group_id"].as_u64().map(|value| value as u32),
+            expiry: otx["expiry"].as_u64().map(|value| value as u32),
+            branch_id: otx["branch_id"].as_u64().map(|value| value as u32),
+        })
+        .collect();
+
+    let payment_reqs: Vec<crate::thp::types::BtcPaymentRequest> = json["payment_reqs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|pr| crate::thp::types::BtcPaymentRequest {
+            nonce: pr["nonce"].as_str().map(hex_to_bytes),
+            recipient_name: pr["recipient_name"].as_str().unwrap().to_string(),
+            memos: pr["memos"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|m| match m["type"].as_str().unwrap() {
+                    "text" => crate::thp::types::BtcPaymentRequestMemo::Text {
+                        text: m["text"].as_str().unwrap().to_string(),
+                    },
+                    "text_details" => crate::thp::types::BtcPaymentRequestMemo::TextDetails {
+                        title: m["title"].as_str().unwrap().to_string(),
+                        text: m["text"].as_str().unwrap().to_string(),
+                    },
+                    "refund" => crate::thp::types::BtcPaymentRequestMemo::Refund {
+                        address: m["address"].as_str().unwrap().to_string(),
+                        path: parse_path(m["path"].as_str().unwrap()),
+                        mac: hex_to_bytes(m["mac"].as_str().unwrap()),
+                    },
+                    "coin_purchase" => crate::thp::types::BtcPaymentRequestMemo::CoinPurchase {
+                        coin_type: m["coin_type"].as_u64().unwrap() as u32,
+                        amount: m["amount"].as_str().unwrap().to_string(),
+                        address: m["address"].as_str().unwrap().to_string(),
+                        path: parse_path(m["path"].as_str().unwrap()),
+                        mac: hex_to_bytes(m["mac"].as_str().unwrap()),
+                    },
+                    other => panic!("unsupported memo type: {other}"),
+                })
+                .collect(),
+            amount: pr["amount"].as_str().map(|s| {
+                crate::thp::types::BtcPaymentRequestAmount::from_sats(s.parse::<u64>().unwrap())
+            }),
+            signature: hex_to_bytes(pr["signature"].as_str().unwrap()),
+        })
+        .collect();
+
+    crate::thp::types::BtcSignTx {
+        version: json["version"].as_u64().unwrap() as u32,
+        lock_time: json["lock_time"].as_u64().unwrap() as u32,
+        inputs,
+        outputs,
+        ref_txs,
+        orig_txs,
+        payment_reqs,
+        chunkify: false,
+    }
+}
+
+#[test]
+fn rbf_fee_bump_fixture_full_request_sequence() {
+    let btc = load_rbf_fixture();
+    let ref_txs_by_hash = build_ref_txs_index(&btc);
+    let orig_txs_by_hash = build_orig_txs_index(&btc);
+
+    assert_eq!(btc.inputs.len(), 2);
+    assert_eq!(btc.outputs.len(), 2);
+    assert_eq!(btc.ref_txs.len(), 2);
+    assert_eq!(btc.orig_txs.len(), 1);
+    assert_eq!(btc.payment_reqs.len(), 1);
+    assert_eq!(btc.payment_reqs[0].recipient_name, "Acme Coffee Co.");
+
+    let fixture_json: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../../tests/data/bitcoin/btc_rbf_with_payment_req.json"
+    ))
+    .unwrap();
+    let sequence = fixture_json["firmware_request_sequence"]
+        .as_array()
+        .unwrap();
+
+    let mut ack_count = 0u32;
+    let mut finished = false;
+
+    for (step, entry) in sequence.iter().enumerate() {
+        let req_type_str = entry["type"].as_str().unwrap();
+
+        let request_type = match req_type_str {
+            "TXINPUT" => Some(BitcoinTxRequestType::TxInput),
+            "TXOUTPUT" => Some(BitcoinTxRequestType::TxOutput),
+            "TXMETA" => Some(BitcoinTxRequestType::TxMeta),
+            "TXORIGINPUT" => Some(BitcoinTxRequestType::TxOrigInput),
+            "TXORIGOUTPUT" => Some(BitcoinTxRequestType::TxOrigOutput),
+            "TXPAYMENTREQ" => Some(BitcoinTxRequestType::TxPaymentReq),
+            "TXFINISHED" => Some(BitcoinTxRequestType::TxFinished),
+            other => panic!("unknown request type in fixture step {step}: {other}"),
+        };
+
+        let tx_hash = entry["tx_hash"].as_str().map(hex_to_bytes);
+
+        let tx_request = DecodedBitcoinTxRequest {
+            request_type,
+            request_index: entry["index"].as_u64().map(|v| v as u32),
+            tx_hash,
+            extra_data_len: None,
+            extra_data_offset: None,
+            signature_index: None,
+            signature: None,
+            serialized_tx: None,
+        };
+
+        let result =
+            handle_bitcoin_tx_request(&btc, &ref_txs_by_hash, &orig_txs_by_hash, &tx_request)
+                .unwrap_or_else(|e| panic!("step {step} ({req_type_str}): unexpected error: {e}"));
+
+        match result {
+            BitcoinTxRequestHandling::Ack(ack) => {
+                if req_type_str == "TXPAYMENTREQ" {
+                    assert_eq!(
+                        ack.message_type,
+                        crate::thp::proto::MESSAGE_TYPE_BITCOIN_TX_ACK_PAYMENT_REQUEST,
+                        "step {step}: TXPAYMENTREQ should produce payment-request ack"
+                    );
+                } else {
+                    assert_eq!(
+                        ack.message_type,
+                        crate::thp::proto::MESSAGE_TYPE_BITCOIN_TX_ACK,
+                        "step {step} ({req_type_str}): expected standard tx ack"
+                    );
+                }
+                ack_count += 1;
+            }
+            BitcoinTxRequestHandling::Finished => {
+                assert_eq!(req_type_str, "TXFINISHED", "step {step}: unexpected finish");
+                finished = true;
+            }
+            BitcoinTxRequestHandling::Continue => {
+                panic!("step {step} ({req_type_str}): unexpected Continue");
+            }
+        }
+    }
+
+    assert!(finished, "sequence must end with TXFINISHED");
+    assert_eq!(ack_count, 14, "expected 14 ack responses in the sequence");
 }

--- a/crates/trezor-connect/src/thp/backend.rs
+++ b/crates/trezor-connect/src/thp/backend.rs
@@ -80,6 +80,8 @@ pub trait ThpBackend: Send {
         request: GetAddressRequest,
     ) -> BackendResult<GetAddressResponse>;
 
+    async fn get_nonce(&mut self) -> BackendResult<Vec<u8>>;
+
     async fn sign_message(
         &mut self,
         request: SignMessageRequest,

--- a/crates/trezor-connect/src/thp/mod.rs
+++ b/crates/trezor-connect/src/thp/mod.rs
@@ -18,10 +18,11 @@ pub use storage::{FileStorage, HostSnapshot, StorageError, ThpStorage};
 pub use thp_proto::hw::trezor::messages::thp as messages;
 pub use transport::{ThpTransport, TransportError};
 pub use types::{
-    BtcInputScriptType, BtcOutputScriptType, BtcRefTx, BtcRefTxInput, BtcRefTxOutput, BtcSignInput,
-    BtcSignOutput, BtcSignTx, CreateSessionRequest, Eip712StructMember, Eip712TypedData,
-    EthAccessListEntry, GetAddressRequest, GetAddressResponse, HostConfig, PairingController,
-    PairingDecision, PairingMethod, SignMessageRequest, SignMessageResponse, SignTxRequest,
-    SignTxResponse, SignTypedDataPayload, SignTypedDataRequest, SignTypedDataResponse,
+    BtcInputScriptType, BtcOrigTx, BtcOutputScriptType, BtcPaymentRequest, BtcPaymentRequestAmount,
+    BtcPaymentRequestMemo, BtcRefTx, BtcRefTxInput, BtcRefTxOutput, BtcSignInput, BtcSignOutput,
+    BtcSignTx, CreateSessionRequest, Eip712StructMember, Eip712TypedData, EthAccessListEntry,
+    GetAddressRequest, GetAddressResponse, HostConfig, PairingController, PairingDecision,
+    PairingMethod, SignMessageRequest, SignMessageResponse, SignTxRequest, SignTxResponse,
+    SignTypedDataPayload, SignTypedDataRequest, SignTypedDataResponse,
 };
 pub use workflow::ThpWorkflow;

--- a/crates/trezor-connect/src/thp/proto/bitcoin.rs
+++ b/crates/trezor-connect/src/thp/proto/bitcoin.rs
@@ -5,9 +5,9 @@ use prost::Message;
 
 use super::{EncodedMessage, ProtoMappingError};
 use crate::thp::types::{
-    BtcInputScriptType, BtcOutputScriptType, BtcRefTx, BtcRefTxInput, BtcRefTxOutput, BtcSignInput,
-    BtcSignOutput, GetAddressRequest, GetAddressResponse, SignMessageRequest, SignMessageResponse,
-    SignTxRequest,
+    BtcInputScriptType, BtcOrigTx, BtcOutputScriptType, BtcPaymentRequest, BtcPaymentRequestMemo,
+    BtcRefTx, BtcRefTxInput, BtcRefTxOutput, BtcSignInput, BtcSignOutput, GetAddressRequest,
+    GetAddressResponse, SignMessageRequest, SignMessageResponse, SignTxRequest,
 };
 
 const MESSAGE_TYPE_BITCOIN_GET_ADDRESS: u16 = 29;
@@ -19,6 +19,8 @@ pub const MESSAGE_TYPE_BITCOIN_MESSAGE_SIGNATURE: u16 = 40;
 pub const MESSAGE_TYPE_BITCOIN_SIGN_TX: u16 = 15;
 pub const MESSAGE_TYPE_BITCOIN_TX_REQUEST: u16 = 21;
 pub const MESSAGE_TYPE_BITCOIN_TX_ACK: u16 = 22;
+/// `TxAckPaymentRequest` — sent in response to a `TXPAYMENTREQ` firmware request.
+pub const MESSAGE_TYPE_BITCOIN_TX_ACK_PAYMENT_REQUEST: u16 = 37;
 
 #[derive(Clone, PartialEq, Message)]
 struct BitcoinGetAddress {
@@ -241,6 +243,12 @@ struct BitcoinTxInput {
     script_type: Option<i32>,
     #[prost(uint64, optional, tag = "8")]
     amount: Option<u64>,
+    #[prost(bytes = "vec", optional, tag = "13")]
+    witness: Option<Vec<u8>>,
+    #[prost(bytes = "vec", optional, tag = "16")]
+    orig_hash: Option<Vec<u8>>,
+    #[prost(uint32, optional, tag = "17")]
+    orig_index: Option<u32>,
 }
 
 #[derive(Clone, PartialEq, Message)]
@@ -274,6 +282,12 @@ struct BitcoinTxOutput {
     script_type: Option<i32>,
     #[prost(bytes = "vec", optional, tag = "6")]
     op_return_data: Option<Vec<u8>>,
+    #[prost(bytes = "vec", optional, tag = "10")]
+    orig_hash: Option<Vec<u8>>,
+    #[prost(uint32, optional, tag = "11")]
+    orig_index: Option<u32>,
+    #[prost(uint32, optional, tag = "12")]
+    payment_req_index: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, prost::Enumeration)]
@@ -287,6 +301,74 @@ enum BitcoinOutputScriptTypeProto {
     PayToP2ShWitness = 5,
     PayToTaproot = 6,
 }
+
+// ── TxAckPaymentRequest proto structs ────────────────────────────────────────
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoTextMemo {
+    #[prost(string, optional, tag = "1")]
+    text: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoRefundMemo {
+    #[prost(string, required, tag = "1")]
+    address: String,
+    #[prost(uint32, repeated, packed = "false", tag = "2")]
+    address_n: Vec<u32>,
+    #[prost(bytes = "vec", required, tag = "3")]
+    mac: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoCoinPurchaseMemo {
+    #[prost(uint32, required, tag = "1")]
+    coin_type: u32,
+    #[prost(string, required, tag = "2")]
+    amount: String,
+    #[prost(string, required, tag = "3")]
+    address: String,
+    #[prost(uint32, repeated, packed = "false", tag = "4")]
+    address_n: Vec<u32>,
+    #[prost(bytes = "vec", required, tag = "5")]
+    mac: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoTextDetailsMemo {
+    #[prost(string, required, tag = "1")]
+    title: String,
+    #[prost(string, required, tag = "2")]
+    text: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoPaymentRequestMemo {
+    #[prost(message, optional, tag = "1")]
+    text_memo: Option<ProtoTextMemo>,
+    #[prost(message, optional, tag = "2")]
+    refund_memo: Option<ProtoRefundMemo>,
+    #[prost(message, optional, tag = "3")]
+    coin_purchase_memo: Option<ProtoCoinPurchaseMemo>,
+    #[prost(message, optional, tag = "4")]
+    text_details_memo: Option<ProtoTextDetailsMemo>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct ProtoTxAckPaymentRequest {
+    #[prost(bytes = "vec", optional, tag = "1")]
+    nonce: Option<Vec<u8>>,
+    #[prost(string, required, tag = "2")]
+    recipient_name: String,
+    #[prost(message, repeated, tag = "3")]
+    memos: Vec<ProtoPaymentRequestMemo>,
+    #[prost(bytes = "vec", optional, tag = "6")]
+    amount: Option<Vec<u8>>,
+    #[prost(bytes = "vec", required, tag = "5")]
+    signature: Vec<u8>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 pub(super) fn encode_get_address_request(
     request: &GetAddressRequest,
@@ -547,6 +629,35 @@ pub fn encode_bitcoin_tx_ack_meta(
     })
 }
 
+pub fn encode_bitcoin_tx_ack_orig_meta(
+    tx: &BtcOrigTx,
+) -> Result<EncodedMessage, ProtoMappingError> {
+    let message = BitcoinTxAck {
+        tx: Some(BitcoinTxAckTransaction {
+            version: Some(tx.version),
+            inputs: Vec::new(),
+            bin_outputs: Vec::new(),
+            lock_time: Some(tx.lock_time),
+            outputs: Vec::new(),
+            inputs_cnt: Some(tx.inputs.len() as u32),
+            outputs_cnt: Some(tx.outputs.len() as u32),
+            extra_data: None,
+            extra_data_len: tx.extra_data.as_ref().map(|data| data.len() as u32),
+            expiry: tx.expiry,
+            overwintered: None,
+            version_group_id: tx.version_group_id,
+            timestamp: tx.timestamp,
+            branch_id: tx.branch_id,
+        }),
+    };
+    let mut payload = Vec::new();
+    message.encode(&mut payload)?;
+    Ok(EncodedMessage {
+        message_type: MESSAGE_TYPE_BITCOIN_TX_ACK,
+        payload,
+    })
+}
+
 pub fn encode_bitcoin_tx_ack_input(
     input: &BtcSignInput,
 ) -> Result<EncodedMessage, ProtoMappingError> {
@@ -557,10 +668,13 @@ pub fn encode_bitcoin_tx_ack_input(
                 address_n: input.path.clone(),
                 prev_hash: input.prev_hash.clone(),
                 prev_index: input.prev_index,
-                script_sig: None,
+                script_sig: input.script_sig.clone(),
                 sequence: Some(input.sequence),
                 script_type: Some(bitcoin_input_script_type_to_proto(input.script_type)),
                 amount: Some(input.amount),
+                witness: input.witness.clone(),
+                orig_hash: input.orig_hash.clone(),
+                orig_index: input.orig_index,
             }],
             bin_outputs: Vec::new(),
             lock_time: None,
@@ -599,6 +713,9 @@ pub fn encode_bitcoin_tx_ack_output(
                 amount: output.amount,
                 script_type: Some(bitcoin_output_script_type_to_proto(output.script_type)),
                 op_return_data: output.op_return_data.clone(),
+                orig_hash: output.orig_hash.clone(),
+                orig_index: output.orig_index,
+                payment_req_index: output.payment_req_index,
             }],
             inputs_cnt: None,
             outputs_cnt: None,
@@ -660,6 +777,9 @@ pub fn encode_bitcoin_tx_ack_prev_input(
                 sequence: Some(input.sequence),
                 script_type: None,
                 amount: None,
+                witness: None,
+                orig_hash: None,
+                orig_index: None,
             }],
             bin_outputs: Vec::new(),
             lock_time: None,
@@ -744,10 +864,89 @@ pub fn encode_bitcoin_tx_ack_prev_extra_data(
     })
 }
 
+/// Encodes a `TxAckPaymentRequest` response to a firmware `TXPAYMENTREQ` request.
+///
+/// The firmware sends `TxRequest { type: TXPAYMENTREQ, details.request_index: N }` and
+/// expects the host to reply with the payment-request data at index N from the caller-
+/// supplied list.  Most signing flows have no payment requests; this encoder is only
+/// invoked when the firmware explicitly asks for one.
+pub fn encode_bitcoin_tx_ack_payment_request(
+    pr: &BtcPaymentRequest,
+) -> Result<EncodedMessage, ProtoMappingError> {
+    let memos: Vec<ProtoPaymentRequestMemo> = pr
+        .memos
+        .iter()
+        .map(|m| match m {
+            BtcPaymentRequestMemo::Text { text } => ProtoPaymentRequestMemo {
+                text_memo: Some(ProtoTextMemo {
+                    text: Some(text.clone()),
+                }),
+                refund_memo: None,
+                coin_purchase_memo: None,
+                text_details_memo: None,
+            },
+            BtcPaymentRequestMemo::TextDetails { title, text } => ProtoPaymentRequestMemo {
+                text_memo: None,
+                refund_memo: None,
+                coin_purchase_memo: None,
+                text_details_memo: Some(ProtoTextDetailsMemo {
+                    title: title.clone(),
+                    text: text.clone(),
+                }),
+            },
+            BtcPaymentRequestMemo::Refund { address, path, mac } => ProtoPaymentRequestMemo {
+                text_memo: None,
+                refund_memo: Some(ProtoRefundMemo {
+                    address: address.clone(),
+                    address_n: path.clone(),
+                    mac: mac.clone(),
+                }),
+                coin_purchase_memo: None,
+                text_details_memo: None,
+            },
+            BtcPaymentRequestMemo::CoinPurchase {
+                coin_type,
+                amount,
+                address,
+                path,
+                mac,
+            } => ProtoPaymentRequestMemo {
+                text_memo: None,
+                refund_memo: None,
+                coin_purchase_memo: Some(ProtoCoinPurchaseMemo {
+                    coin_type: *coin_type,
+                    amount: amount.clone(),
+                    address: address.clone(),
+                    address_n: path.clone(),
+                    mac: mac.clone(),
+                }),
+                text_details_memo: None,
+            },
+        })
+        .collect();
+
+    let message = ProtoTxAckPaymentRequest {
+        nonce: pr.nonce.clone(),
+        recipient_name: pr.recipient_name.clone(),
+        memos,
+        amount: pr.amount.as_ref().map(|amount| amount.0.clone()),
+        signature: pr.signature.clone(),
+    };
+    let mut payload = Vec::new();
+    message.encode(&mut payload)?;
+    Ok(EncodedMessage {
+        message_type: MESSAGE_TYPE_BITCOIN_TX_ACK_PAYMENT_REQUEST,
+        payload,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::thp::types::{BtcSignTx, GetAddressRequest, SignMessageRequest};
+    use crate::thp::types::{
+        BtcPaymentRequest, BtcPaymentRequestAmount, BtcPaymentRequestMemo, BtcSignTx,
+        GetAddressRequest, SignMessageRequest,
+    };
 
     #[test]
     fn encodes_bitcoin_get_address_request() {
@@ -856,6 +1055,10 @@ mod tests {
                 amount: 1234,
                 sequence: 0xffff_fffd,
                 script_type: BtcInputScriptType::SpendWitness,
+                script_sig: None,
+                witness: None,
+                orig_hash: None,
+                orig_index: None,
             }],
             outputs: vec![BtcSignOutput {
                 address: Some("bc1qtest".to_string()),
@@ -863,8 +1066,13 @@ mod tests {
                 amount: 1000,
                 script_type: BtcOutputScriptType::PayToAddress,
                 op_return_data: None,
+                orig_hash: None,
+                orig_index: None,
+                payment_req_index: Some(0),
             }],
             ref_txs: Vec::new(),
+            orig_txs: Vec::new(),
+            payment_reqs: Vec::new(),
             chunkify: false,
         });
         let (encoded, offset) = encode_sign_tx_request(&request).unwrap();
@@ -875,6 +1083,81 @@ mod tests {
         assert_eq!(decoded.inputs_count, 1);
         assert_eq!(decoded.outputs_count, 1);
         assert_eq!(decoded.version, Some(2));
+    }
+
+    #[test]
+    fn encodes_bitcoin_output_ack_payment_request_index() {
+        let output = BtcSignOutput {
+            address: Some("bc1qtest".to_string()),
+            path: Vec::new(),
+            amount: 1000,
+            script_type: BtcOutputScriptType::PayToAddress,
+            op_return_data: None,
+            orig_hash: None,
+            orig_index: None,
+            payment_req_index: Some(0),
+        };
+
+        let encoded = encode_bitcoin_tx_ack_output(&output).unwrap();
+        let decoded = BitcoinTxAck::decode(encoded.payload.as_slice()).unwrap();
+        assert_eq!(decoded.tx.unwrap().outputs[0].payment_req_index, Some(0));
+    }
+
+    #[test]
+    fn encodes_payment_request_with_full_schema() {
+        let request = BtcPaymentRequest {
+            nonce: Some(vec![0x01, 0x02, 0x03]),
+            recipient_name: "Test Merchant".to_string(),
+            memos: vec![
+                BtcPaymentRequestMemo::Text {
+                    text: "Invoice #42".to_string(),
+                },
+                BtcPaymentRequestMemo::TextDetails {
+                    title: "Details".to_string(),
+                    text: "Extra context".to_string(),
+                },
+                BtcPaymentRequestMemo::Refund {
+                    address: "tb1qrefund".to_string(),
+                    path: vec![0x8000_0001, 0x8000_0000, 0x8000_0000, 1, 0],
+                    mac: vec![0xaa, 0xbb],
+                },
+                BtcPaymentRequestMemo::CoinPurchase {
+                    coin_type: 1,
+                    amount: "0.025 BTC".to_string(),
+                    address: "tb1qcoinpurchase".to_string(),
+                    path: vec![0x8000_0001, 0x8000_0000, 0x8000_0000, 1, 1],
+                    mac: vec![0xcc, 0xdd],
+                },
+            ],
+            amount: Some(BtcPaymentRequestAmount::from_sats(900)),
+            signature: vec![0xde, 0xad],
+        };
+
+        let encoded = encode_bitcoin_tx_ack_payment_request(&request).unwrap();
+        assert_eq!(
+            encoded.message_type,
+            MESSAGE_TYPE_BITCOIN_TX_ACK_PAYMENT_REQUEST
+        );
+
+        let decoded = ProtoTxAckPaymentRequest::decode(encoded.payload.as_slice()).unwrap();
+        assert_eq!(decoded.nonce, Some(vec![0x01, 0x02, 0x03]));
+        assert_eq!(decoded.recipient_name, "Test Merchant");
+        assert_eq!(decoded.amount, Some(900u64.to_le_bytes().to_vec()));
+        assert_eq!(decoded.signature, vec![0xde, 0xad]);
+        assert!(decoded.memos[0].text_memo.is_some());
+        assert!(decoded.memos[1].text_details_memo.is_some());
+        assert_eq!(
+            decoded.memos[2].refund_memo.as_ref().unwrap().address_n,
+            vec![0x8000_0001, 0x8000_0000, 0x8000_0000, 1, 0]
+        );
+        assert_eq!(
+            decoded.memos[3]
+                .coin_purchase_memo
+                .as_ref()
+                .unwrap()
+                .address_n,
+            vec![0x8000_0001, 0x8000_0000, 0x8000_0000, 1, 1]
+        );
     }
 
     #[test]

--- a/crates/trezor-connect/src/thp/proto/mod.rs
+++ b/crates/trezor-connect/src/thp/proto/mod.rs
@@ -17,10 +17,12 @@ use super::types::{
 
 pub use bitcoin::{
     BitcoinTxRequestType, DecodedBitcoinTxRequest, MESSAGE_TYPE_BITCOIN_SIGN_TX,
-    MESSAGE_TYPE_BITCOIN_TX_ACK, MESSAGE_TYPE_BITCOIN_TX_REQUEST, decode_bitcoin_tx_request,
-    encode_bitcoin_tx_ack_input, encode_bitcoin_tx_ack_meta, encode_bitcoin_tx_ack_output,
-    encode_bitcoin_tx_ack_prev_extra_data, encode_bitcoin_tx_ack_prev_input,
-    encode_bitcoin_tx_ack_prev_meta, encode_bitcoin_tx_ack_prev_output,
+    MESSAGE_TYPE_BITCOIN_TX_ACK, MESSAGE_TYPE_BITCOIN_TX_ACK_PAYMENT_REQUEST,
+    MESSAGE_TYPE_BITCOIN_TX_REQUEST, decode_bitcoin_tx_request, encode_bitcoin_tx_ack_input,
+    encode_bitcoin_tx_ack_meta, encode_bitcoin_tx_ack_orig_meta, encode_bitcoin_tx_ack_output,
+    encode_bitcoin_tx_ack_payment_request, encode_bitcoin_tx_ack_prev_extra_data,
+    encode_bitcoin_tx_ack_prev_input, encode_bitcoin_tx_ack_prev_meta,
+    encode_bitcoin_tx_ack_prev_output,
 };
 pub use ethereum::{
     DecodedTypedDataResponse, ETH_DATA_CHUNK_SIZE, EthereumDataTypeProto, EthereumFieldType,
@@ -50,9 +52,22 @@ pub enum ProtoMappingError {
     UnexpectedMessage(u16),
 }
 
+#[derive(Debug)]
 pub struct EncodedMessage {
     pub message_type: u16,
     pub payload: Vec<u8>,
+}
+
+const MESSAGE_TYPE_GET_NONCE: u16 = 31;
+const MESSAGE_TYPE_NONCE: u16 = 33;
+
+#[derive(Clone, PartialEq, Message)]
+struct GetNonce {}
+
+#[derive(Clone, PartialEq, Message)]
+struct Nonce {
+    #[prost(bytes = "vec", required, tag = "1")]
+    nonce: Vec<u8>,
 }
 
 fn encode_message<M: Message>(
@@ -245,6 +260,25 @@ pub fn encode_end_request() -> Result<EncodedMessage, ProtoMappingError> {
     )
 }
 
+pub fn encode_get_nonce_request() -> Result<EncodedMessage, ProtoMappingError> {
+    let mut payload = Vec::new();
+    GetNonce {}.encode(&mut payload)?;
+    Ok(EncodedMessage {
+        message_type: MESSAGE_TYPE_GET_NONCE,
+        payload,
+    })
+}
+
+pub fn decode_get_nonce_response(
+    message_type: u16,
+    payload: &[u8],
+) -> Result<Vec<u8>, ProtoMappingError> {
+    if message_type != MESSAGE_TYPE_NONCE {
+        return Err(ProtoMappingError::UnexpectedMessage(message_type));
+    }
+    Ok(Nonce::decode(payload)?.nonce)
+}
+
 pub fn decode_device_properties(payload: &[u8]) -> Result<ThpProperties, ProtoMappingError> {
     let msg = messages::ThpDeviceProperties::decode(payload)?;
     let pairing_methods = proto_to_pairing_methods(&msg.pairing_methods)?;
@@ -406,6 +440,8 @@ mod tests {
             inputs: Vec::new(),
             outputs: Vec::new(),
             ref_txs: Vec::new(),
+            orig_txs: Vec::new(),
+            payment_reqs: Vec::new(),
             chunkify: false,
         });
         let sol = SignTxRequest::solana(
@@ -436,5 +472,21 @@ mod tests {
         assert_eq!(eth_msg.message_type, 56);
         assert_eq!(btc_msg.message_type, 29);
         assert_eq!(sol_msg.message_type, 902);
+    }
+
+    #[test]
+    fn encodes_and_decodes_get_nonce() {
+        let encoded = encode_get_nonce_request().unwrap();
+        assert_eq!(encoded.message_type, MESSAGE_TYPE_GET_NONCE);
+
+        let mut payload = Vec::new();
+        Nonce {
+            nonce: vec![0xAA; 32],
+        }
+        .encode(&mut payload)
+        .unwrap();
+
+        let decoded = decode_get_nonce_response(MESSAGE_TYPE_NONCE, &payload).unwrap();
+        assert_eq!(decoded, vec![0xAA; 32]);
     }
 }

--- a/crates/trezor-connect/src/thp/types.rs
+++ b/crates/trezor-connect/src/thp/types.rs
@@ -429,6 +429,10 @@ pub struct BtcSignInput {
     pub amount: u64,
     pub sequence: u32,
     pub script_type: BtcInputScriptType,
+    pub script_sig: Option<Vec<u8>>,
+    pub witness: Option<Vec<u8>>,
+    pub orig_hash: Option<Vec<u8>>,
+    pub orig_index: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -438,6 +442,9 @@ pub struct BtcSignOutput {
     pub amount: u64,
     pub script_type: BtcOutputScriptType,
     pub op_return_data: Option<Vec<u8>>,
+    pub orig_hash: Option<Vec<u8>>,
+    pub orig_index: Option<u32>,
+    pub payment_req_index: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -469,12 +476,87 @@ pub struct BtcRefTx {
 }
 
 #[derive(Debug, Clone)]
+pub struct BtcOrigTx {
+    pub hash: Vec<u8>,
+    pub version: u32,
+    pub lock_time: u32,
+    pub inputs: Vec<BtcSignInput>,
+    pub outputs: Vec<BtcSignOutput>,
+    pub extra_data: Option<Vec<u8>>,
+    pub timestamp: Option<u32>,
+    pub version_group_id: Option<u32>,
+    pub expiry: Option<u32>,
+    pub branch_id: Option<u32>,
+}
+
+/// A single memo attached to a payment request.
+#[derive(Debug, Clone)]
+pub enum BtcPaymentRequestMemo {
+    /// Plain-text human-readable note shown to the user.
+    Text { text: String },
+    /// Plain-text heading and details shown together.
+    TextDetails { title: String, text: String },
+    /// Refund address in case the payment cannot be fulfilled.
+    Refund {
+        address: String,
+        path: Vec<u32>,
+        mac: Vec<u8>,
+    },
+    /// Coin-purchase details (exchange / swap flows).
+    CoinPurchase {
+        coin_type: u32,
+        amount: String,
+        address: String,
+        path: Vec<u32>,
+        mac: Vec<u8>,
+    },
+}
+
+/// Encoded SLIP-24 payment request amount.
+///
+/// The firmware expects little-endian bytes, typically 8 bytes for Bitcoin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BtcPaymentRequestAmount(pub Vec<u8>);
+
+impl BtcPaymentRequestAmount {
+    /// Encodes a Bitcoin amount as 8-byte little-endian satoshis.
+    pub fn from_sats(amount: u64) -> Self {
+        Self(amount.to_le_bytes().to_vec())
+    }
+}
+
+/// Represents a `TxAckPaymentRequest` value carried by the caller and returned
+/// to the firmware when it sends a `TxRequest` with type `TXPAYMENTREQ`.
+///
+/// Payment requests implement a Trezor-internal BIP-70 successor protocol.
+/// For most signing flows this list will be empty; the field exists so that
+/// callers who do need payment-request support can supply the data without a
+/// separate API change.
+#[derive(Debug, Clone)]
+pub struct BtcPaymentRequest {
+    /// Random nonce supplied by the recipient (anti-replay).
+    pub nonce: Option<Vec<u8>>,
+    /// Human-readable merchant / recipient name.
+    pub recipient_name: String,
+    /// Optional structured memos (text, refund, coin-purchase).
+    pub memos: Vec<BtcPaymentRequestMemo>,
+    /// Encoded payment amount bytes as defined by SLIP-24.
+    pub amount: Option<BtcPaymentRequestAmount>,
+    /// Recipient's signature over the serialised request.
+    pub signature: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
 pub struct BtcSignTx {
     pub version: u32,
     pub lock_time: u32,
     pub inputs: Vec<BtcSignInput>,
     pub outputs: Vec<BtcSignOutput>,
     pub ref_txs: Vec<BtcRefTx>,
+    pub orig_txs: Vec<BtcOrigTx>,
+    /// Payment requests indexed by the `request_index` field in `TxRequest`.
+    /// Most signing flows leave this empty.
+    pub payment_reqs: Vec<BtcPaymentRequest>,
     pub chunkify: bool,
 }
 

--- a/crates/trezor-connect/src/thp/workflow.rs
+++ b/crates/trezor-connect/src/thp/workflow.rs
@@ -605,6 +605,13 @@ where
         self.backend.get_address(request).await.map_err(Into::into)
     }
 
+    pub async fn get_nonce(&mut self) -> Result<Vec<u8>> {
+        if self.state.phase() != Phase::Paired {
+            return Err(ThpWorkflowError::InvalidPhase);
+        }
+        self.backend.get_nonce().await.map_err(Into::into)
+    }
+
     pub async fn sign_tx(&mut self, request: SignTxRequest) -> Result<SignTxResponse> {
         if self.state.phase() != Phase::Paired {
             return Err(ThpWorkflowError::InvalidPhase);

--- a/crates/trezor-connect/src/thp/workflow/tests.rs
+++ b/crates/trezor-connect/src/thp/workflow/tests.rs
@@ -350,6 +350,10 @@ impl ThpBackend for MockBackend {
         })
     }
 
+    async fn get_nonce(&mut self) -> BackendResult<Vec<u8>> {
+        Ok(vec![0xAA; 32])
+    }
+
     async fn sign_message(
         &mut self,
         request: SignMessageRequest,
@@ -809,6 +813,27 @@ async fn get_address_requires_paired_phase() {
             0,
             0,
         ]))
+        .await
+        .expect_err("should fail before pairing");
+    assert!(matches!(err, ThpWorkflowError::InvalidPhase));
+}
+
+#[tokio::test]
+async fn get_nonce_requires_paired_phase() {
+    let backend = MockBackend::autopair();
+    let mut workflow = ThpWorkflow::new(
+        backend,
+        HostConfig {
+            pairing_methods: vec![PairingMethod::SkipPairing],
+            known_credentials: vec![],
+            static_key: None,
+            host_name: "host".into(),
+            app_name: "app".into(),
+        },
+    );
+
+    let err = workflow
+        .get_nonce()
         .await
         .expect_err("should fail before pairing");
     assert!(matches!(err, ThpWorkflowError::InvalidPhase));

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,6 +1,6 @@
 # hw-core Execution Plan
 
-Last updated: 2026-02-23
+Last updated: 2026-03-09
 Status legend: TODO | IN_PROGRESS | DONE | BLOCKED
 
 ## Objective
@@ -18,12 +18,15 @@ Status: IN_PROGRESS
 - `ref_txs` request model, validation, and prev-tx payload support.
 - Implemented handling for `TXMETA`, `TXINPUT`, `TXOUTPUT`, `TXEXTRADATA`.
 - Added proto/wallet/backend tests for prev-tx and bounds validation.
+- Implemented `TXORIGINPUT` handling (RBF fee-bump: returns current tx input at index).
+- Implemented `TXORIGOUTPUT` handling (RBF: returns current tx output at index).
+- Implemented `TXPAYMENTREQ` handling: added `BtcPaymentRequest` / `BtcPaymentRequestMemo` types,
+  `TxAckPaymentRequest` proto encoder, and handler in `ble.rs`.
+- Added unit tests for all three new request types including bounds-check error cases.
 
 ### Remaining
-- [ ] Implement `TXORIGINPUT` handling.
-- [ ] Implement `TXORIGOUTPUT` handling.
-- [ ] Implement `TXPAYMENTREQ` handling.
-- [ ] Add integration tests for mixed `TX*` request sequences.
+- [ ] Add integration tests for mixed `TX*` request sequences (e.g. Input → OrigInput → PaymentReq).
+- [ ] Validate on real device with a server-signed SLIP-24 payment request using live nonce and authenticated address MACs (not fixture data).
 
 ### Exit Criteria
 - BTC signing no longer fails on advanced firmware request variants.
@@ -99,7 +102,7 @@ Status: IN_PROGRESS
 ### Remaining
 - [ ] Add/verify real-device regression coverage for pair/connect/address/sign/disconnect across repeated runs.
 - [ ] Finalize Android reconnect policy and lifecycle UX parity with iOS sample.
-- [ ] Add instrumentation smoke test for app launch and core controls.
+- [x] Add instrumentation smoke test for app launch and core controls (PR #19: AppSmokeTest.kt).
 
 ### Exit Criteria
 - A contributor can run Android sample happy path locally from repo docs, including stable pair/connect/address/sign/disconnect on real device.
@@ -170,6 +173,7 @@ Status: TODO
 - [ ] `just cli-pair` succeeds on first pairing and reuse path.
 - [ ] `just cli-address-eth` and `just cli-sign-eth` succeed on paired device.
 - [ ] BTC signing validates both supported and unsupported advanced request paths clearly.
+- [ ] BTC SLIP-24 payment-request signing is exercised against a real signing backend/server on hardware (fresh nonce, authenticated MACs, server signature).
 - [ ] `just test-ios-ui` and `just test-mac-ui` pass.
 - [x] Android sample launch/build smoke passes (`just build-android`, Gradle assembleDebug).
 - [x] Android sample real-device `connect-ready` reaches `SESSION_READY` without timing out at `CREATE_CHANNEL`.

--- a/tests/data/bitcoin/btc_rbf_with_payment_req.json
+++ b/tests/data/bitcoin/btc_rbf_with_payment_req.json
@@ -1,0 +1,183 @@
+{
+  "description": "RBF fee-bump scenario: 2-input/2-output native SegWit tx with a payment request. Exercises TXORIGINPUT, TXORIGOUTPUT, and TXPAYMENTREQ firmware request types.",
+  "version": 2,
+  "lock_time": 831400,
+  "inputs": [
+    {
+      "path": "m/84'/0'/0'/0/3",
+      "prev_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "prev_index": 0,
+      "amount": "50000",
+      "sequence": 4294967293,
+      "script_type": "spendwitness",
+      "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "orig_index": 0
+    },
+    {
+      "path": "m/84'/0'/0'/0/7",
+      "prev_hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+      "prev_index": 1,
+      "amount": "30000",
+      "sequence": 4294967293,
+      "script_type": "spendwitness",
+      "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "orig_index": 1
+    }
+  ],
+  "outputs": [
+    {
+      "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      "amount": "60000",
+      "script_type": "paytowitness",
+      "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "orig_index": 0,
+      "payment_req_index": 0
+    },
+    {
+      "path": "m/84'/0'/0'/1/2",
+      "amount": "18500",
+      "script_type": "paytowitness",
+      "orig_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "orig_index": 1
+    }
+  ],
+  "ref_txs": [
+    {
+      "hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "version": 2,
+      "lock_time": 831200,
+      "inputs": [
+        {
+          "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "prev_index": 0,
+          "script_sig": "",
+          "sequence": 4294967293
+        }
+      ],
+      "bin_outputs": [
+        {
+          "amount": "50000",
+          "script_pubkey": "00149d5e0fb75d36c7b94c0dc4c03e3c8f0b68e23e71"
+        },
+        {
+          "amount": "49000",
+          "script_pubkey": "0014d85c2b71d0060b09c9886aeb815e50991dda124d"
+        }
+      ]
+    },
+    {
+      "hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+      "version": 2,
+      "lock_time": 831100,
+      "inputs": [
+        {
+          "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
+          "prev_index": 0,
+          "script_sig": "",
+          "sequence": 4294967293
+        },
+        {
+          "prev_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
+          "prev_index": 2,
+          "script_sig": "483045022100abcdef",
+          "sequence": 4294967293
+        }
+      ],
+      "bin_outputs": [
+        {
+          "amount": "10000",
+          "script_pubkey": "0014a11ce08a1b5c4b1f1b8e3ea8dbb7f26f60e2c1a0"
+        },
+        {
+          "amount": "30000",
+          "script_pubkey": "001425e03ad0c5c96b45920de82fc2e2e84c72e3f5ab"
+        }
+      ]
+    }
+  ],
+  "orig_txs": [
+    {
+      "hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "version": 2,
+      "lock_time": 831350,
+      "inputs": [
+        {
+          "path": "m/84'/0'/0'/0/3",
+          "prev_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "prev_index": 0,
+          "amount": "50000",
+          "sequence": 4294967293,
+          "script_type": "spendwitness",
+          "script_sig": "",
+          "witness": "0x024730"
+        },
+        {
+          "path": "m/84'/0'/0'/0/7",
+          "prev_hash": "0xa665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+          "prev_index": 1,
+          "amount": "30000",
+          "sequence": 4294967293,
+          "script_type": "spendwitness",
+          "script_sig": "",
+          "witness": "0x034731"
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+          "amount": "60000",
+          "script_type": "paytowitness",
+          "payment_req_index": 0
+        },
+        {
+          "path": "m/84'/0'/0'/1/2",
+          "amount": "19000",
+          "script_type": "paytowitness"
+        }
+      ]
+    }
+  ],
+  "payment_reqs": [
+    {
+      "nonce": "0x48656c6c6f",
+      "recipient_name": "Acme Coffee Co.",
+      "memos": [
+        { "type": "text", "text": "Order #1337 — 2 espresso" },
+        { "type": "text_details", "title": "Pickup", "text": "Thank you for your purchase" },
+        {
+          "type": "refund",
+          "address": "tb1qrefundexample0000000000000000000000000",
+          "path": "m/84'/1'/0'/1/0",
+          "mac": "0x01020304"
+        },
+        {
+          "type": "coin_purchase",
+          "coin_type": 0,
+          "amount": "0.001 BTC",
+          "address": "bc1qcoinpurchase0000000000000000000000000",
+          "path": "m/84'/0'/0'/1/1",
+          "mac": "0x05060708"
+        }
+      ],
+      "amount": "60000",
+      "signature": "0x304402207a8e4bdc3be50b8544ec76476ed7813942c5e0dd74298691e3a0c3a77a90c60c02202e94e8e6ffc99ccd35f7ab3e4a7a52d2e2c8e3f8f4a5c6b7d8e9f0a1b2c3d4e5"
+    }
+  ],
+  "firmware_request_sequence": [
+    { "type": "TXINPUT", "index": 0 },
+    { "type": "TXINPUT", "index": 1 },
+    { "type": "TXMETA", "tx_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" },
+    { "type": "TXINPUT", "index": 0, "tx_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" },
+    { "type": "TXOUTPUT", "index": 0, "tx_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" },
+    { "type": "TXOUTPUT", "index": 1, "tx_hash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" },
+    { "type": "TXPAYMENTREQ", "index": 0 },
+    { "type": "TXOUTPUT", "index": 0 },
+    { "type": "TXOUTPUT", "index": 1 },
+    { "type": "TXMETA", "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111" },
+    { "type": "TXORIGINPUT", "index": 0, "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111" },
+    { "type": "TXORIGINPUT", "index": 1, "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111" },
+    { "type": "TXORIGOUTPUT", "index": 0, "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111" },
+    { "type": "TXORIGOUTPUT", "index": 1, "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111" },
+    { "type": "TXFINISHED" }
+  ]
+}


### PR DESCRIPTION
## Workstream A: Bitcoin Signing Completion

**What's in this PR:**

### TXORIGINPUT / TXORIGOUTPUT (RBF fee-bump support)
- Firmware sends `TXORIGINPUT` / `TXORIGOUTPUT` when performing Replace-By-Fee fee bump, asking the host to re-supply current-tx inputs/outputs for amount verification
- Reuses existing `encode_bitcoin_tx_ack_input` / `encode_bitcoin_tx_ack_output` encoders
- Indexes into `btc.inputs` / `btc.outputs` (no `tx_hash` expected on these requests)
- Bounds-checked with descriptive `BackendError::Transport` on out-of-range index

### TXPAYMENTREQ (payment-request protocol)
- Added `BtcPaymentRequest` + `BtcPaymentRequestMemo` types (`Text | Refund | CoinPurchase`) to `thp/types.rs`
- Added `payment_reqs: Vec<BtcPaymentRequest>` field to `BtcSignTx` (empty by default — no breaking change for existing callers)
- Added `ProtoTxAckPaymentRequest` prost structs (field layout matches Trezor messages-bitcoin.proto)
- Added `encode_bitcoin_tx_ack_payment_request()` encoder (message type 37)
- Re-exported through `thp/proto/mod.rs`
- Handled in `handle_bitcoin_tx_request()` in `ble.rs`

### Tests (6 new cases in `ble/tests.rs`)
| Test | Description |
|------|-------------|
| `handles_tx_orig_input_request` | Happy path, asserts TX_ACK |
| `handles_tx_orig_output_request` | Happy path, asserts TX_ACK |
| `tx_orig_input_out_of_bounds_is_error` | Bounds-check error regression |
| `tx_orig_output_out_of_bounds_is_error` | Bounds-check error regression |
| `handles_tx_payment_req_request` | Text-memo payment request → TX_ACK_PAYMENT_REQUEST |
| `tx_payment_req_missing_entry_is_error` | Empty payment_reqs error path |

**Propagation:**
- `hw-wallet/btc.rs`: add `payment_reqs: Vec::new()` to `BtcSignTx` construction
- All test sites updated with new field

**Context:** Workstream A of the [hw-core execution plan](docs/plan.md). Addresses the three remaining `TXORIGINPUT` / `TXORIGOUTPUT` / `TXPAYMENTREQ` TODO items.

## Test plan
- `cargo check --package trezor-connect` — clean (no errors, no warnings)
- `cargo test --lib --package trezor-connect` — new tests included (CI will run on dbus-enabled runner)