### PR TITLE
fix(trezor-connect): collect per-input signatures in Bitcoin sign_tx

### DIFF
--- a/crates/hw-cli/src/commands/test_support.rs
+++ b/crates/hw-cli/src/commands/test_support.rs
@@ -279,6 +279,7 @@ pub fn canned_eth_sign_response() -> SignTxResponse {
         v: 0,
         r: vec![0xAA; 32],
         s: vec![0xBB; 32],
+        signatures: Vec::new(),
     }
 }
 
@@ -288,6 +289,7 @@ pub fn canned_sol_sign_response() -> SignTxResponse {
         v: 0,
         r: vec![0xCC; 64],
         s: Vec::new(),
+        signatures: Vec::new(),
     }
 }
 
@@ -297,6 +299,7 @@ pub fn canned_btc_sign_response() -> SignTxResponse {
         v: 0,
         r: vec![0xDD; 64],
         s: Vec::new(),
+        signatures: vec![vec![0xDD; 64]],
     }
 }
 

--- a/crates/hw-ffi/src/ble/tests.rs
+++ b/crates/hw-ffi/src/ble/tests.rs
@@ -248,6 +248,7 @@ impl ThpBackend for MockBackend {
             v: 0,
             r: vec![0xAA; 32],
             s: vec![0xBB; 32],
+            signatures: Vec::new(),
         })
     }
 

--- a/crates/hw-ffi/src/ble/workflow_ops.rs
+++ b/crates/hw-ffi/src/ble/workflow_ops.rs
@@ -74,6 +74,7 @@ where
         v: response.v,
         r: response.r,
         s: response.s,
+        signatures: response.signatures,
         tx_hash: verification.as_ref().map(|sig| sig.tx_hash.to_vec()),
         recovered_address: verification.map(|sig| sig.recovered_address),
     })

--- a/crates/hw-ffi/src/types.rs
+++ b/crates/hw-ffi/src/types.rs
@@ -256,6 +256,11 @@ pub struct SignTxResult {
     pub v: u32,
     pub r: Vec<u8>,
     pub s: Vec<u8>,
+    /// Per-input signatures collected during signing, indexed by input.
+    ///
+    /// Populated for Bitcoin (one entry per signed input); empty for
+    /// Ethereum and Solana, which return a single signature via `r`/`s`.
+    pub signatures: Vec<Vec<u8>>,
     pub tx_hash: Option<Vec<u8>>,
     pub recovered_address: Option<String>,
 }

--- a/crates/hw-wallet/src/eth.rs
+++ b/crates/hw-wallet/src/eth.rs
@@ -322,6 +322,7 @@ mod tests {
             v: u32::from(recovery_id.to_byte()),
             r: signature.r().to_bytes().to_vec(),
             s: signature.s().to_bytes().to_vec(),
+            signatures: Vec::new(),
         };
 
         let verified = verify_sign_tx_response(&request, &response).unwrap();

--- a/crates/trezor-connect/src/ble/backend_impl.rs
+++ b/crates/trezor-connect/src/ble/backend_impl.rs
@@ -690,7 +690,13 @@ impl ThpBackend for BleBackend {
                         tx_request.signature_s,
                     ) {
                         self.state.set_expected_responses(&[]);
-                        return Ok(SignTxResponse { chain, v, r, s });
+                        return Ok(SignTxResponse {
+                            chain,
+                            v,
+                            r,
+                            s,
+                            signatures: Vec::new(),
+                        });
                     }
 
                     if let Some(requested_len) = tx_request.data_length {
@@ -734,6 +740,7 @@ impl ThpBackend for BleBackend {
                     v: 0,
                     r: signature,
                     s: Vec::new(),
+                    signatures: Vec::new(),
                 })
             }
             Chain::Bitcoin => {
@@ -742,7 +749,17 @@ impl ThpBackend for BleBackend {
                 })?;
                 let ref_txs_by_hash = build_ref_txs_index(&btc);
                 let orig_txs_by_hash = build_orig_txs_index(&btc);
-                let mut latest_signature: Option<Vec<u8>> = None;
+                // Collect per-input signatures, indexed by the device's
+                // `signature_index`. The Bitcoin signing flow streams one
+                // signature per signed input; keeping only the latest is
+                // incorrect for multi-input transactions, where each input
+                // has a distinct sighash and therefore a distinct signature.
+                let mut signatures: Vec<Vec<u8>> = Vec::new();
+                // Fallback for flows that deliver a signature without a
+                // `signature_index` (e.g. on TXFINISHED from older firmware).
+                // Keeps `SignTxResponse.r` populated for single-signature
+                // consumers that still read the legacy field.
+                let mut last_signature: Option<Vec<u8>> = None;
 
                 loop {
                     let (message_type, payload) = self.read_signing_message().await?;
@@ -757,7 +774,14 @@ impl ThpBackend for BleBackend {
                     let tx_request = decode_bitcoin_tx_request(message_type, &payload)
                         .map_err(Self::transport_error)?;
                     if let Some(signature) = tx_request.signature.as_ref() {
-                        latest_signature = Some(signature.clone());
+                        last_signature = Some(signature.clone());
+                        if let Some(idx) = tx_request.signature_index {
+                            let idx = idx as usize;
+                            if signatures.len() <= idx {
+                                signatures.resize(idx + 1, Vec::new());
+                            }
+                            signatures[idx] = signature.clone();
+                        }
                     }
 
                     match handle_bitcoin_tx_request(
@@ -771,11 +795,22 @@ impl ThpBackend for BleBackend {
                         }
                         BitcoinTxRequestHandling::Finished => {
                             self.state.set_expected_responses(&[]);
+                            // Preserve the legacy `r` field: prefer the last
+                            // indexed signature (current multi-input flow),
+                            // and fall back to any un-indexed signature seen
+                            // (legacy single-signature flow). New consumers
+                            // should prefer the `signatures` vector.
+                            let r = signatures
+                                .last()
+                                .cloned()
+                                .or_else(|| last_signature.clone())
+                                .unwrap_or_default();
                             return Ok(SignTxResponse {
                                 chain,
                                 v: 0,
-                                r: latest_signature.unwrap_or_default(),
+                                r,
                                 s: Vec::new(),
+                                signatures,
                             });
                         }
                         BitcoinTxRequestHandling::Continue => {

--- a/crates/trezor-connect/src/thp/types.rs
+++ b/crates/trezor-connect/src/thp/types.rs
@@ -730,6 +730,13 @@ pub struct SignTxResponse {
     pub v: u32,
     pub r: Vec<u8>,
     pub s: Vec<u8>,
+    /// Per-input signatures collected during transaction signing,
+    /// indexed by the device's `signature_index`.
+    ///
+    /// Currently populated for Bitcoin signing, where the device streams
+    /// one signature per input; empty for Ethereum and Solana, which
+    /// produce a single signature exposed via `r`/`s`.
+    pub signatures: Vec<Vec<u8>>,
 }
 
 #[async_trait::async_trait]

--- a/crates/trezor-connect/src/thp/workflow/tests.rs
+++ b/crates/trezor-connect/src/thp/workflow/tests.rs
@@ -382,6 +382,7 @@ impl ThpBackend for MockBackend {
             v: 1,
             r: vec![0xAA; 32],
             s: vec![0xBB; 32],
+            signatures: Vec::new(),
         })
     }
 


### PR DESCRIPTION
## Summary

Bitcoin transaction signing in Trezor's THP protocol streams one signature per input via `BitcoinTxRequest` messages tagged with `signature_index`. The previous implementation kept only the latest signature in `SignTxResponse.r`, which is incorrect for any multi-input transaction: each input has a distinct sighash and therefore a distinct signature, but consumers received only the last one. As a result, multi-input PSBTs signed through this library ended up with every input carrying input N-1's signature, and validation failed.

## Changes

- Add `signatures: Vec<Vec<u8>>` to `SignTxResponse` (`crates/trezor-connect/src/thp/types.rs`), populated by the BLE backend with one entry per signed input, indexed by the device's `signature_index` (`crates/trezor-connect/src/ble/backend_impl.rs`).
- Preserve the legacy `r` field with the last signature so existing single-signature consumers (CLI, mock backends, Eth/Solana flows which leave the new field empty) keep working unchanged.
- Propagate the new field through the hw-ffi UniFFI bindings (`crates/hw-ffi/src/types.rs`, `crates/hw-ffi/src/ble/workflow_ops.rs`) so foreign-language clients can consume per-input signatures.
- Default-init `signatures: Vec::new()` in existing test fixtures / mock backends.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p trezor-connect -p hw-ffi --all-targets -- -D warnings`
- [x] `cargo test -p trezor-connect --lib` (79 passed)
- [x] `cargo test -p hw-ffi --lib` (14 passed)
- [x] `cargo test -p hw-wallet --lib` (52 passed)
- [x] End-to-end verified against a 2-input P2WSH multisig PSBT on a Trezor Safe 7 over BLE: both inputs now receive distinct, valid signatures.
