### PR TITLE
fix(trezor-connect): handle THP retransmitted frames on BLE

### DIFF
--- a/crates/trezor-connect/src/ble.rs
+++ b/crates/trezor-connect/src/ble.rs
@@ -402,7 +402,7 @@ pub struct BleBackend {
     rx_buffer: Vec<u8>,
     continuation: Vec<u8>,
     pending_chunk: Option<ChunkAccumulator>,
-    last_sent_encrypted_frame: Option<Vec<u8>>,
+    last_sent_sync_frame: Option<Vec<u8>>,
 }
 
 impl BleBackend {
@@ -416,7 +416,7 @@ impl BleBackend {
             rx_buffer: Vec::new(),
             continuation: Vec::new(),
             pending_chunk: None,
-            last_sent_encrypted_frame: None,
+            last_sent_sync_frame: None,
         }
     }
 
@@ -463,6 +463,12 @@ impl BleBackend {
             trace!("BLE THP TX frame: magic=0x{magic:02x} len={}", frame.len());
         } else {
             debug!("BLE THP TX frame: magic=0x{magic:02x} len={}", frame.len());
+        }
+        // Cache sync-toggling frames (handshake + encrypted protobuf) so we can
+        // replay them if the peer later retransmits its last response — the
+        // replay covers our original reply having been dropped on the air.
+        if wire::should_toggle_sync(base_magic) {
+            self.last_sent_sync_frame = Some(frame.clone());
         }
         let mtu = {
             let link = self.inner.link_mut();
@@ -554,6 +560,31 @@ impl BleBackend {
     async fn read_next(&mut self) -> BackendResult<ParsedMessage> {
         loop {
             if let Some(mut parsed) = self.try_parse()? {
+                // Detect retransmits for any sync-toggling frame (handshake
+                // responses and encrypted protobuf). Over BLE Write-Without-
+                // Response the peer retransmits its last reply when it does
+                // not see ours; acknowledging and replaying keeps the session
+                // from deadlocking with both sides waiting on each other.
+                if wire::should_toggle_sync(parsed.header.magic)
+                    && parsed.header.seq_bit != self.state.recv_bit()
+                {
+                    debug!(
+                        magic = format_args!("0x{:02x}", parsed.header.magic),
+                        expected_seq = self.state.recv_bit(),
+                        got_seq = parsed.header.seq_bit,
+                        "BLE THP retransmitted frame; re-ACKing and replaying last outbound"
+                    );
+                    let ack = wire::encode_ack(self.state.channel(), parsed.header.seq_bit);
+                    self.send_frame(ack).await?;
+                    if let Some(frame) = self.last_sent_sync_frame.clone() {
+                        self.send_frame(frame).await?;
+                    } else {
+                        debug!(
+                            "BLE THP retransmit detected but no cached outbound frame; waiting for next message"
+                        );
+                    }
+                    continue;
+                }
                 match &mut parsed.response {
                     WireResponse::Ack => continue,
                     WireResponse::Continuation(chunk) => {
@@ -561,28 +592,6 @@ impl BleBackend {
                         continue;
                     }
                     WireResponse::Protobuf { payload } => {
-                        let is_encrypted_data = matches!(
-                            parsed.header.magic,
-                            MAGIC_CONTROL_ENCRYPTED | wire::MAGIC_CONTROL_DECRYPTED
-                        );
-                        if is_encrypted_data && parsed.header.seq_bit != self.state.recv_bit() {
-                            debug!(
-                                expected_seq = self.state.recv_bit(),
-                                got_seq = parsed.header.seq_bit,
-                                payload_len = payload.len(),
-                                "BLE THP retransmitted encrypted frame; re-ACKing and replaying last outbound"
-                            );
-                            let ack = wire::encode_ack(self.state.channel(), parsed.header.seq_bit);
-                            self.send_frame(ack).await?;
-                            if let Some(frame) = self.last_sent_encrypted_frame.clone() {
-                                self.send_frame(frame).await?;
-                            } else {
-                                debug!(
-                                    "BLE THP retransmit detected but no cached outbound frame; waiting for next message"
-                                );
-                            }
-                            continue;
-                        }
                         if !self.continuation.is_empty() {
                             let mut merged = std::mem::take(&mut self.continuation);
                             merged.extend(payload.iter());
@@ -728,7 +737,6 @@ impl BleBackend {
             encoded.payload.len()
         );
         let frame = self.encrypt_host_message(encoded.message_type, &encoded.payload)?;
-        self.last_sent_encrypted_frame = Some(frame.clone());
         self.send_frame(frame).await?;
         self.state.on_send(MAGIC_CONTROL_ENCRYPTED);
         Ok(())

--- a/crates/trezor-connect/src/ble.rs
+++ b/crates/trezor-connect/src/ble.rs
@@ -402,6 +402,7 @@ pub struct BleBackend {
     rx_buffer: Vec<u8>,
     continuation: Vec<u8>,
     pending_chunk: Option<ChunkAccumulator>,
+    last_sent_encrypted_frame: Option<Vec<u8>>,
 }
 
 impl BleBackend {
@@ -415,6 +416,7 @@ impl BleBackend {
             rx_buffer: Vec::new(),
             continuation: Vec::new(),
             pending_chunk: None,
+            last_sent_encrypted_frame: None,
         }
     }
 
@@ -559,6 +561,28 @@ impl BleBackend {
                         continue;
                     }
                     WireResponse::Protobuf { payload } => {
+                        let is_encrypted_data = matches!(
+                            parsed.header.magic,
+                            MAGIC_CONTROL_ENCRYPTED | wire::MAGIC_CONTROL_DECRYPTED
+                        );
+                        if is_encrypted_data && parsed.header.seq_bit != self.state.recv_bit() {
+                            debug!(
+                                expected_seq = self.state.recv_bit(),
+                                got_seq = parsed.header.seq_bit,
+                                payload_len = payload.len(),
+                                "BLE THP retransmitted encrypted frame; re-ACKing and replaying last outbound"
+                            );
+                            let ack = wire::encode_ack(self.state.channel(), parsed.header.seq_bit);
+                            self.send_frame(ack).await?;
+                            if let Some(frame) = self.last_sent_encrypted_frame.clone() {
+                                self.send_frame(frame).await?;
+                            } else {
+                                debug!(
+                                    "BLE THP retransmit detected but no cached outbound frame; waiting for next message"
+                                );
+                            }
+                            continue;
+                        }
                         if !self.continuation.is_empty() {
                             let mut merged = std::mem::take(&mut self.continuation);
                             merged.extend(payload.iter());
@@ -704,6 +728,7 @@ impl BleBackend {
             encoded.payload.len()
         );
         let frame = self.encrypt_host_message(encoded.message_type, &encoded.payload)?;
+        self.last_sent_encrypted_frame = Some(frame.clone());
         self.send_frame(frame).await?;
         self.state.on_send(MAGIC_CONTROL_ENCRYPTED);
         Ok(())

--- a/crates/trezor-connect/src/thp/wire.rs
+++ b/crates/trezor-connect/src/thp/wire.rs
@@ -34,7 +34,7 @@ fn is_handshake_magic(magic: u8) -> bool {
     )
 }
 
-fn should_toggle_sync(magic: u8) -> bool {
+pub(crate) fn should_toggle_sync(magic: u8) -> bool {
     !matches!(
         magic,
         MAGIC_CREATE_CHANNEL_REQUEST | MAGIC_CREATE_CHANNEL_RESPONSE | MAGIC_READ_ACK


### PR DESCRIPTION
fix(trezor-connect): handle THP retransmitted frames on BLE

Over BLE, encrypted data frames are sent with Write Without Response,
which is fire-and-forget at the ATT layer. If a packet is dropped on
air, the peer does not see our reply, times out, and retransmits the
last encrypted frame it sent us. This is the recovery mechanism THP
v2 is designed to support via its per-direction sequence bits.

Previously the host transport treated every incoming encrypted frame
as a new message: it ACKed, decrypted with the next AEAD nonce, and
advanced recv_nonce and recv_bit. A retransmitted frame carries the
sequence bit of the already-processed frame, so our expected nonce is
one ahead of the peer's - AEAD-GCM tag verification fails and the
session aborts.

Fix the transport so it recognises retransmitted encrypted frames and
keeps the session in sync:

- On the RX side, when an encrypted frame arrives with
  seq_bit != state.recv_bit(), treat it as a retransmission. Do not
  decrypt and do not call on_receive, which would skip a nonce that
  belongs to the next real frame. Re-ACK the frame with its own
  seq_bit so the peer stops retransmitting.
- Cache the last outbound encrypted frame and replay it when a
  retransmit is detected. If the peer retransmitted, our last reply
  very likely never reached it, and without replay the session
  deadlocks with each side waiting for the other.

The replayed frame is sent as-is: it was encrypted with a specific
nonce when it was first produced, and the peer expects that exact
nonce to decrypt it. No THP state is advanced by the replay.

The change is local to BleBackend and does not alter the THP wire
format, nonce schedule, or the external backend API. On a reliable
link the new code path never fires.
