### PR TITLE
fix(trezor-connect): recover BLE retransmits by recent-response CRC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ cargo fmt --all
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
+## Comments and Docstrings
+
+- Comments and docstrings are opt-in, not default.
+- When needed, keep them to a single line.
+- Prefer no comment unless it explains intent, invariants, or safety that the code cannot make obvious on its own.
+
 ## Source of Truth for Behavior
 
 - When debugging protocol/flow mismatches, always check the Trezor Suite implementation first: `~/workspace/github/trezor-suite`

--- a/crates/ble-transport/examples/scan_trezor.rs
+++ b/crates/ble-transport/examples/scan_trezor.rs
@@ -1,8 +1,3 @@
-//! Example that scans for Trezor Safe 7 devices using the btleplug backend.
-//!
-//! Run with:
-//! `cargo run -p ble-transport --example scan_trezor`
-
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};

--- a/crates/ble-transport/src/session.rs
+++ b/crates/ble-transport/src/session.rs
@@ -85,8 +85,6 @@ impl BleSession {
 
         #[cfg(not(target_os = "android"))]
         {
-            // Keep iOS/macOS behavior where a small probe write helps surface
-            // pairing/auth failures before THP starts.
             peripheral
                 .write(&write_char, PROOF_OF_CONNECTION, WriteType::WithResponse)
                 .await?;
@@ -120,8 +118,6 @@ impl BleSession {
         let mtu_hint = profile.mtu_hint.map(|m| m as usize).unwrap_or(244);
         #[cfg(target_os = "android")]
         let mtu = {
-            // btleplug 0.12 negotiates ATT MTU during connect() on Android.
-            // Use the negotiated MTU payload size, but keep our profile/env caps.
             let negotiated_payload = peripheral.mtu().saturating_sub(3) as usize;
             let safe_cap = std::env::var("HWCORE_BLE_ANDROID_TX_MTU")
                 .ok()

--- a/crates/hw-chain/src/lib.rs
+++ b/crates/hw-chain/src/lib.rs
@@ -1,77 +1,52 @@
 use std::str::FromStr;
 
-/// Default BIP-32 derivation path for Ethereum accounts (EIP-44, coin type 60).
 pub const DEFAULT_ETHEREUM_BIP32_PATH: &str = "m/44'/60'/0'/0/0";
 
-/// Default BIP-32 derivation path for Bitcoin accounts using BIP-84 (native SegWit, coin type 0).
 pub const DEFAULT_BITCOIN_BIP32_PATH: &str = "m/84'/0'/0'/0/0";
 
-/// Default BIP-32 derivation path for Solana accounts (coin type 501).
 pub const DEFAULT_SOLANA_BIP32_PATH: &str = "m/44'/501'/0'/0'";
 
-/// Short identifier string for the Ethereum chain (`"eth"`).
 pub const CHAIN_ETH: &str = "eth";
 
-/// Short identifier string for the Bitcoin chain (`"btc"`).
 pub const CHAIN_BTC: &str = "btc";
 
-/// Short identifier string for the Solana chain (`"sol"`).
 pub const CHAIN_SOL: &str = "sol";
 
-/// Static configuration for a supported blockchain.
-///
-/// Bundles the short chain code, SLIP-44 coin type, and the default BIP-32
-/// derivation path used when the caller does not supply an explicit path.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ChainConfig {
-    /// Short lowercase code used in CLI flags and configuration (e.g. `"eth"`).
     pub code: &'static str,
-    /// [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) coin-type index.
     pub slip44: u32,
-    /// Default BIP-32 derivation path string (e.g. `"m/44'/60'/0'/0/0"`).
     pub default_path: &'static str,
 }
 
-/// Pre-built [`ChainConfig`] for Ethereum / EVM-compatible chains.
 pub const ETHEREUM_CONFIG: ChainConfig = ChainConfig {
     code: CHAIN_ETH,
     slip44: 60,
     default_path: DEFAULT_ETHEREUM_BIP32_PATH,
 };
 
-/// Pre-built [`ChainConfig`] for Bitcoin (native SegWit / BIP-84).
 pub const BITCOIN_CONFIG: ChainConfig = ChainConfig {
     code: CHAIN_BTC,
     slip44: 0,
     default_path: DEFAULT_BITCOIN_BIP32_PATH,
 };
 
-/// Pre-built [`ChainConfig`] for Solana.
 pub const SOLANA_CONFIG: ChainConfig = ChainConfig {
     code: CHAIN_SOL,
     slip44: 501,
     default_path: DEFAULT_SOLANA_BIP32_PATH,
 };
 
-/// A blockchain supported by the hw-core library.
-///
-/// Use [`Chain::config`] to retrieve the associated [`ChainConfig`] (SLIP-44
-/// coin type, default derivation path, etc.).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Chain {
-    /// Ethereum and EVM-compatible networks.
     Ethereum,
-    /// Bitcoin (native SegWit / BIP-84).
     Bitcoin,
-    /// Solana.
     Solana,
 }
 
 impl Chain {
-    /// All supported chains in a fixed-size array, useful for iteration.
     pub const ALL: [Self; 3] = [Self::Ethereum, Self::Bitcoin, Self::Solana];
 
-    /// Returns the static [`ChainConfig`] for this chain.
     pub const fn config(self) -> ChainConfig {
         match self {
             Self::Ethereum => ETHEREUM_CONFIG,
@@ -80,18 +55,14 @@ impl Chain {
         }
     }
 
-    /// Returns the default BIP-32 derivation path string for this chain.
     pub fn default_path(self) -> &'static str {
         self.config().default_path
     }
 
-    /// Returns the short lowercase chain identifier (e.g. `"eth"`, `"btc"`, `"sol"`).
     pub fn as_str(self) -> &'static str {
         self.config().code
     }
 
-    /// Returns the [`Chain`] whose SLIP-44 coin type matches `slip44`, or
-    /// `None` if the coin type is not recognised.
     pub fn from_slip44(slip44: u32) -> Option<Self> {
         Self::ALL
             .into_iter()
@@ -102,14 +73,6 @@ impl Chain {
 impl FromStr for Chain {
     type Err = String;
 
-    /// Parses a chain from a string (case-insensitive).
-    ///
-    /// Accepted values:
-    /// - `"eth"` or `"ethereum"` → [`Chain::Ethereum`]
-    /// - `"btc"` or `"bitcoin"`  → [`Chain::Bitcoin`]
-    /// - `"sol"` or `"solana"`   → [`Chain::Solana`]
-    ///
-    /// Matching is case-insensitive, so `"ETH"`, `"Eth"`, and `"eth"` are all valid.
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value.to_ascii_lowercase().as_str() {
             "eth" | "ethereum" => Ok(Self::Ethereum),
@@ -144,7 +107,6 @@ mod tests {
         assert_eq!("bitcoin".parse::<Chain>().unwrap(), Chain::Bitcoin);
         assert_eq!("sol".parse::<Chain>().unwrap(), Chain::Solana);
         assert_eq!("solana".parse::<Chain>().unwrap(), Chain::Solana);
-        // case-insensitive
         assert_eq!("ETH".parse::<Chain>().unwrap(), Chain::Ethereum);
         assert_eq!("Ethereum".parse::<Chain>().unwrap(), Chain::Ethereum);
         assert_eq!("BTC".parse::<Chain>().unwrap(), Chain::Bitcoin);

--- a/crates/hw-cli/src/cli.rs
+++ b/crates/hw-cli/src/cli.rs
@@ -9,7 +9,7 @@ use hw_wallet::chain::Chain;
 pub struct Cli {
     #[arg(short, long, action = ArgAction::Count, global = true)]
     pub verbose: u8,
-    /// Skip interactive pairing (for headless/CI use with emulator).
+    /// Skip interactive pairing for headless or emulator-driven runs.
     #[arg(long, global = true, default_value_t = false)]
     pub skip_pairing: bool,
     #[command(subcommand)]

--- a/crates/hw-cli/tests/emu_ble.rs
+++ b/crates/hw-cli/tests/emu_ble.rs
@@ -1,15 +1,3 @@
-//! Integration tests that exercise the full BLE→THP stack against the Trezor
-//! T3W1 emulator via the bluez-emu-bridge.
-//!
-//! These tests are `#[ignore]`d by default — they require:
-//!   - Linux (D-Bus + BlueZ mock)
-//!   - The T3W1 emulator binary (set `TREZOR_EMU_BINARY`)
-//!   - The vendored bluez-emu-bridge (set `BRIDGE_DIR`)
-//!   - Python 3 with `trezor`, `dbus-fast`, `click`, `typing-extensions`
-//!
-//! Run with:
-//!   cargo test -p hw-cli --test emu_ble -- --ignored --nocapture --test-threads=1
-
 use std::process::Command;
 
 #[path = "../../../tests/fixtures/emulator_harness.rs"]
@@ -38,7 +26,6 @@ fn run_hw_cli(harness: &EmulatorHarness, args: &[&str]) -> (String, String) {
     (stdout, stderr)
 }
 
-/// Full BLE scan → connect → THP handshake → get ETH address.
 #[test]
 #[ignore = "requires T3W1 emulator binary and Linux D-Bus (see CONTRIBUTING)"]
 fn emu_ble_get_eth_address() {
@@ -59,14 +46,12 @@ fn emu_ble_get_eth_address() {
         ],
     );
 
-    // SLIP-14 test seed produces a deterministic ETH address
     assert!(
         stdout.contains("0x"),
         "expected ETH address in output, got: {stdout}"
     );
 }
 
-/// Full BLE scan → connect → THP handshake → sign ETH transaction.
 #[test]
 #[ignore = "requires T3W1 emulator binary and Linux D-Bus (see CONTRIBUTING)"]
 fn emu_ble_sign_eth_tx() {

--- a/crates/hw-ffi/bin/generate_bindings.rs
+++ b/crates/hw-ffi/bin/generate_bindings.rs
@@ -13,11 +13,11 @@ use uniffi_bindgen::bindings::{self, GenerateOptions, TargetLanguage};
     disable_help_subcommand = true
 )]
 struct Args {
-    /// Path to the compiled hw-ffi dynamic library.
+    /// Path to a compiled `hw-ffi` dynamic library.
     #[arg(long, value_name = "PATH", conflicts_with = "auto")]
     lib: Option<PathBuf>,
 
-    /// Force auto-discovery of the compiled library in target/{debug,release}.
+    /// Auto-discover the library under `target/{debug,release}`.
     #[arg(long, conflicts_with = "lib")]
     auto: bool,
 

--- a/crates/hw-ffi/src/errors.rs
+++ b/crates/hw-ffi/src/errors.rs
@@ -1,4 +1,3 @@
-/// Simplified error surface exposed via UniFFI bindings.
 #[derive(Debug, uniffi::Error, thiserror::Error, Clone)]
 #[uniffi(flat_error)]
 pub enum HWCoreError {

--- a/crates/hw-ffi/src/types.rs
+++ b/crates/hw-ffi/src/types.rs
@@ -256,10 +256,7 @@ pub struct SignTxResult {
     pub v: u32,
     pub r: Vec<u8>,
     pub s: Vec<u8>,
-    /// Per-input signatures collected during signing, indexed by input.
-    ///
-    /// Populated for Bitcoin (one entry per signed input); empty for
-    /// Ethereum and Solana, which return a single signature via `r`/`s`.
+    /// Per-input Bitcoin signatures, indexed by the device's `signature_index`.
     pub signatures: Vec<Vec<u8>>,
     pub tx_hash: Option<Vec<u8>>,
     pub recovered_address: Option<String>,

--- a/crates/hw-ffi/tests/emu_ble.rs
+++ b/crates/hw-ffi/tests/emu_ble.rs
@@ -1,8 +1,3 @@
-//! Emulator-backed smoke tests for the Rust FFI surface.
-//!
-//! These tests reuse the Linux BlueZ emulator harness and exercise the same
-//! public handle types that UniFFI exports to Swift/Kotlin consumers.
-
 use hwcore::{
     BleManagerHandle, Chain, GetAddressRequest, HostConfig, PairingMethod, SessionPhase,
     SignMessageRequest, WorkflowEventKind,
@@ -110,9 +105,7 @@ fn skip_pairing_host_config() -> HostConfig {
 }
 
 fn set_dbus_system_bus_address(value: &str) {
-    // SAFETY: emulator integration tests run in a dedicated single-threaded
-    // process in CI (`--test-threads=1`) and set the bus before creating any
-    // BLE manager state.
+    // SAFETY: tests set the bus before any BLE manager state is created.
     unsafe {
         std::env::set_var("DBUS_SYSTEM_BUS_ADDRESS", value);
     }

--- a/crates/hw-wallet/src/bip32.rs
+++ b/crates/hw-wallet/src/bip32.rs
@@ -1,31 +1,7 @@
 use crate::error::{WalletError, WalletResult};
 
-/// The hardened-key bit flag defined by BIP-32 (2^31).
 const HARDENED: u32 = 0x8000_0000;
 
-/// Parses a BIP-32 derivation path string into a vector of 32-bit child-key
-/// indices.
-///
-/// # Format
-///
-/// The path may optionally begin with `"m/"` (master key prefix). Each
-/// component is a decimal integer optionally followed by `'`, `h`, or `H` to
-/// denote a hardened child.
-///
-/// | Input example         | Parsed indices               |
-/// |-----------------------|------------------------------|
-/// | `"m/44'/60'/0'/0/0"`  | `[0x8000002c, 0x8000003c, 0x80000000, 0, 0]` |
-/// | `"44h/1/2H"`          | `[0x8000002c, 1, 0x80000002]`              |
-/// | `"m"`                 | `[]` (master key, no children)             |
-///
-/// # Errors
-///
-/// Returns [`WalletError::InvalidBip32Path`] if:
-/// - the path is empty,
-/// - any segment is empty (double `/`),
-/// - a segment cannot be parsed as a `u32`,
-/// - a segment's numeric value is ≥ 2^31 (which would overflow into the
-///   hardened range after the flag is applied).
 pub fn parse_bip32_path(path: &str) -> WalletResult<Vec<u32>> {
     let trimmed = path.trim();
     if trimmed.is_empty() {

--- a/crates/hw-wallet/src/ble.rs
+++ b/crates/hw-wallet/src/ble.rs
@@ -14,15 +14,10 @@ use trezor_connect::thp::{
 
 use crate::error::{WalletError, WalletResult};
 
-/// Returns the BLE [`BleProfile`] for Trezor Safe 7 devices, or
-/// [`WalletError::ProfileUnavailable`] if the profile was not compiled in.
 pub fn trezor_profile() -> WalletResult<BleProfile> {
     BleProfile::trezor_safe7().ok_or(WalletError::ProfileUnavailable)
 }
 
-/// Scans for BLE devices advertising the given profile for up to `duration`.
-///
-/// Returns a (possibly empty) list of discovered devices.
 pub async fn scan_profile(
     manager: &BleManager,
     profile: BleProfile,
@@ -32,10 +27,6 @@ pub async fn scan_profile(
     Ok(devices)
 }
 
-/// Convenience wrapper that loads the Trezor BLE profile and scans for
-/// devices advertising it.
-///
-/// Returns a tuple of the resolved profile and the discovered devices.
 pub async fn scan_trezor(
     manager: &BleManager,
     duration: Duration,
@@ -45,11 +36,6 @@ pub async fn scan_trezor(
     Ok((profile, devices))
 }
 
-/// Opens a BLE connection to a previously discovered device.
-///
-/// Translates "peer removed pairing info" BLE errors into the structured
-/// [`WalletError::PeerRemovedPairingInfo`] variant so callers can surface a
-/// user-friendly recovery message.
 pub async fn connect_trezor_device(
     device: DiscoveredDevice,
     profile: BleProfile,
@@ -85,29 +71,17 @@ pub fn workflow(backend: BleBackend, config: HostConfig) -> ThpWorkflow<BleBacke
     ThpWorkflow::new(backend, config)
 }
 
-/// Default number of attempts for creating a THP channel.
 pub const CREATE_CHANNEL_ATTEMPTS: usize = 3;
-/// Default number of handshake attempts per connection.
 pub const HANDSHAKE_ATTEMPTS: usize = 2;
-/// Default number of attempts for creating a THP session.
 pub const CREATE_SESSION_ATTEMPTS: usize = 3;
-/// Default delay between retry attempts.
 pub const RETRY_DELAY: Duration = Duration::from_millis(800);
 const CREATE_CHANNEL_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// Configures retry behaviour for the multi-step THP session bootstrap.
-///
-/// All attempt counts are clamped to a minimum of 1. Use
-/// [`SessionRetryPolicy::default`] to get the recommended production settings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionRetryPolicy {
-    /// Maximum number of create-channel attempts before giving up.
     pub create_channel_attempts: u32,
-    /// Maximum number of handshake attempts per connection.
     pub handshake_attempts: u32,
-    /// Maximum number of create-session attempts before giving up.
     pub create_session_attempts: u32,
-    /// Milliseconds to wait between consecutive retry attempts.
     pub retry_delay_ms: u64,
 }
 
@@ -140,46 +114,24 @@ impl SessionRetryPolicy {
     }
 }
 
-/// The current phase of a THP session bootstrap sequence.
-///
-/// Phases must be completed in order. Use [`session_phase`] to compute the
-/// current phase from a [`ThpState`] snapshot.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SessionPhase {
-    /// A THP channel has not yet been established; call `create_channel`.
     NeedsChannel,
-    /// A channel exists but the noise handshake has not completed; call `handshake`.
     NeedsHandshake,
-    /// Awaiting the user to enter the pairing code on the device.
     NeedsPairingCode,
-    /// Awaiting the user to confirm the connection on the device.
     NeedsConnectionConfirmation,
-    /// Pairing is complete; a THP session must still be created.
     NeedsSession,
-    /// A THP session is active and ready for signing requests.
     Ready,
 }
 
-/// A snapshot of what the caller can do given the current [`SessionPhase`].
-///
-/// Constructed via [`session_state`]. All boolean flags are derived deterministically
-/// from the phase; they are provided as a convenience so UI layers do not need
-/// to duplicate the phase-to-capability mapping.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SessionState {
-    /// The current bootstrap phase.
     pub phase: SessionPhase,
-    /// True when only pairing actions (not signing) are possible.
     pub can_pair_only: bool,
-    /// True when a connection/pairing flow can be initiated.
     pub can_connect: bool,
-    /// True when the session is ready to retrieve addresses from the device.
     pub can_get_address: bool,
-    /// True when the session is ready to sign transactions.
     pub can_sign_tx: bool,
-    /// True when the user must enter a pairing code to proceed.
     pub requires_pairing_code: bool,
-    /// Optional human-readable message to display alongside the current phase.
     pub prompt_message: Option<String>,
 }
 
@@ -236,23 +188,13 @@ fn skip_pairing_can_auto_advance(state: &ThpState) -> bool {
         )
 }
 
-/// Options for the full connect-and-bootstrap-session flow.
-///
-/// Use [`Default::default`] to get sane production values and override only
-/// what you need.
 #[derive(Debug, Clone)]
 pub struct SessionBootstrapOptions {
-    /// THP-level operation timeout applied to the BLE backend.
     pub thp_timeout: Duration,
-    /// When `true`, the handshake step will attempt to auto-unlock the device.
     pub try_to_unlock: bool,
-    /// Optional BIP-39 passphrase for the session.
     pub passphrase: Option<String>,
-    /// When `true`, the passphrase is entered on the device rather than the host.
     pub on_device: bool,
-    /// When `true`, derive Cardano keys in addition to the primary chain keys.
     pub derive_cardano: bool,
-    /// Retry configuration for transient failures during bootstrap.
     pub retry_policy: SessionRetryPolicy,
 }
 

--- a/crates/hw-wallet/src/btc.rs
+++ b/crates/hw-wallet/src/btc.rs
@@ -128,7 +128,6 @@ pub struct TxInputPaymentRequestMemo {
     pub amount: Option<String>,
 }
 
-/// JSON representation of a single HD node (matches Trezor `HDNodeType`).
 #[derive(Debug, Deserialize)]
 pub struct TxInputHDNode {
     pub depth: u32,
@@ -138,8 +137,6 @@ pub struct TxInputHDNode {
     pub public_key: String,
 }
 
-/// JSON representation of an HD node with derivation suffix
-/// (matches Trezor `HDNodePathType`).
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum TxInputHDNodeRef {
@@ -163,25 +160,17 @@ pub enum TxInputMultisigPubkeysOrder {
     Lexicographic,
 }
 
-/// JSON representation of multisig metadata
-/// (matches Trezor `MultisigRedeemScriptType`).
 #[derive(Debug, Deserialize)]
 pub struct TxInputMultisig {
-    /// Cosigner HD nodes with derivation suffixes (legacy representation).
     #[serde(default)]
     pub pubkeys: Vec<TxInputHDNodePath>,
-    /// Existing partial signatures in order (hex-encoded; empty string = missing).
     #[serde(default)]
     pub signatures: Vec<String>,
-    /// Required signature threshold.
     pub m: u32,
-    /// Cosigner HD nodes (preferred flat representation).
     #[serde(default)]
     pub nodes: Vec<TxInputHDNode>,
-    /// Common derivation suffix applied to every node in `nodes`.
     #[serde(default)]
     pub address_n: Vec<u32>,
-    /// Ordering policy for `pubkeys`.
     #[serde(default)]
     pub pubkeys_order: TxInputMultisigPubkeysOrder,
 }
@@ -956,7 +945,6 @@ mod tests {
         assert_eq!(request.chain, Chain::Bitcoin);
         let btc = request.btc.unwrap();
 
-        // Input carries a 2-of-3 multisig via `pubkeys` (legacy representation)
         assert_eq!(btc.inputs.len(), 1);
         assert_eq!(btc.inputs[0].script_type, BtcInputScriptType::SpendMultisig);
         let input_ms = btc.inputs[0].multisig.as_ref().expect("input multisig");
@@ -964,20 +952,16 @@ mod tests {
         assert_eq!(input_ms.pubkeys.len(), 3);
         assert_eq!(input_ms.signatures.len(), 3);
         assert_eq!(input_ms.pubkeys_order, BtcMultisigPubkeysOrder::Preserved);
-        // All signatures are empty (unsigned)
         assert!(input_ms.signatures.iter().all(|s| s.is_empty()));
-        // Verify first cosigner HD node fields decoded from the xpub string
         assert_eq!(input_ms.pubkeys[0].node.depth, 4);
         assert_eq!(input_ms.pubkeys[0].node.fingerprint, 0x9DFF_15C0);
         assert_eq!(input_ms.pubkeys[0].node.child_num, 0x8000_0000);
         assert_eq!(input_ms.pubkeys[0].address_n, vec![0, 0]);
         assert_eq!(input_ms.pubkeys[0].node.public_key.len(), 33);
 
-        // Output[0] is a plain paytoaddress (no multisig)
         assert_eq!(btc.outputs[0].multisig, None);
         assert_eq!(btc.outputs[0].amount, 90_000);
 
-        // Output[1] carries a 2-of-3 multisig via `nodes` (flat representation)
         assert_eq!(
             btc.outputs[1].script_type,
             BtcOutputScriptType::PayToMultisig
@@ -990,7 +974,6 @@ mod tests {
             output_ms.pubkeys_order,
             BtcMultisigPubkeysOrder::Lexicographic
         );
-        // pubkeys list is empty when using the flat nodes representation
         assert!(output_ms.pubkeys.is_empty());
     }
 

--- a/crates/hw-wallet/src/chain.rs
+++ b/crates/hw-wallet/src/chain.rs
@@ -5,49 +5,20 @@ pub use hw_chain::{
     DEFAULT_ETHEREUM_BIP32_PATH, DEFAULT_SOLANA_BIP32_PATH,
 };
 
-/// The hardened-key bit (2^31) used when masking coin-type indices.
 const HARDENED_MASK: u32 = 0x8000_0000;
 
-/// The fully-resolved derivation path for a signing request.
-///
-/// Combines the detected or explicit [`Chain`] with the canonical path string
-/// and its parsed index vector so callers do not need to re-parse the path.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ResolvedDerivationPath {
-    /// The blockchain that this path targets.
     pub chain: Chain,
-    /// The canonical BIP-32 path string (e.g. `"m/44'/60'/0'/0/0"`).
     pub path: String,
-    /// The path parsed into a sequence of 32-bit child-key indices.
     pub path_indices: Vec<u32>,
 }
 
-/// Infers the target [`Chain`] from the coin-type component (index 1) of a
-/// parsed BIP-32 path.
-///
-/// Returns `None` if the path has fewer than two components or if the
-/// coin type is not recognised.
 pub fn infer_chain_from_path(path: &[u32]) -> Option<Chain> {
     let coin_type = path.get(1).copied()? & !HARDENED_MASK;
     Chain::from_slip44(coin_type)
 }
 
-/// Resolves a [`ResolvedDerivationPath`] from optional explicit chain and path
-/// overrides.
-///
-/// Resolution rules:
-/// 1. If an explicit path is provided it is parsed; the coin type is used to
-///    infer the chain.
-/// 2. If an explicit chain is also provided it takes precedence, **unless** the
-///    inferred chain from the path differs — in that case an error is returned.
-/// 3. If neither chain nor path is provided, Ethereum with its default path is
-///    used.
-///
-/// # Errors
-///
-/// Returns [`WalletError::InvalidBip32Path`] if:
-/// - the explicit path cannot be parsed, or
-/// - the explicit chain and the chain inferred from the path are different.
 pub fn resolve_derivation_path(
     explicit_chain: Option<Chain>,
     explicit_path: Option<&str>,

--- a/crates/hw-wallet/src/error.rs
+++ b/crates/hw-wallet/src/error.rs
@@ -1,58 +1,36 @@
 use thiserror::Error;
 use trezor_connect::thp::{BackendError, ThpWorkflowError};
 
-/// High-level category for a [`WalletError`].
-///
-/// Used to produce machine-readable error codes (see [`WalletError::code`]) and
-/// to drive retry / recovery logic in callers without string matching.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum WalletErrorKind {
-    /// A Bluetooth Low Energy transport error occurred.
     Ble,
-    /// An error in the THP (Trezor Host Protocol) workflow.
     Workflow,
-    /// The device itself returned an error or is in an unexpected state.
     Device,
-    /// The request was invalid (bad path, unsupported feature, etc.).
     Validation,
-    /// An operation timed out waiting for a device response.
     Timeout,
 }
 
-/// Errors that can occur during high-level hw-wallet operations.
 #[derive(Debug, Error)]
 pub enum WalletError {
-    /// The Trezor Safe 7 BLE profile is not compiled into this binary.
     #[error("trezor-safe7 BLE profile not built into this binary")]
     ProfileUnavailable,
-    /// The supplied BIP-32 path string could not be parsed.
     #[error("invalid BIP32 path: {0}")]
     InvalidBip32Path(String),
-    /// The BLE peer deleted its pairing records; the OS Bluetooth pairing must
-    /// be removed and re-established.
     #[error(
         "BLE peer removed pairing information: remove device from OS Bluetooth settings and pair again"
     )]
     PeerRemovedPairingInfo,
-    /// A BLE transport-layer error was reported by [`ble_transport`].
     #[error("BLE error: {0}")]
     Ble(#[from] ble_transport::BleError),
-    /// The THP workflow layer returned an error.
     #[error("workflow error: {0}")]
     Workflow(#[from] trezor_connect::thp::ThpWorkflowError),
-    /// A cryptographic signing operation failed.
     #[error("signing error: {0}")]
     Signing(String),
 }
 
-/// Convenience type alias for wallet operation results.
 pub type WalletResult<T> = std::result::Result<T, WalletError>;
 
 impl WalletError {
-    /// Returns the high-level [`WalletErrorKind`] for this error.
-    ///
-    /// Useful for branching on error category without exhaustive pattern
-    /// matching on the full error type.
     pub fn kind(&self) -> WalletErrorKind {
         match self {
             Self::ProfileUnavailable | Self::InvalidBip32Path(_) | Self::Signing(_) => {
@@ -70,10 +48,6 @@ impl WalletError {
         }
     }
 
-    /// Returns a short uppercase string code for this error (e.g. `"BLE"`,
-    /// `"TIMEOUT"`).
-    ///
-    /// Suitable for use in JSON API responses or structured logs.
     pub fn code(&self) -> &'static str {
         match self.kind() {
             WalletErrorKind::Ble => "BLE",

--- a/crates/hw-wallet/src/message_signing.rs
+++ b/crates/hw-wallet/src/message_signing.rs
@@ -6,7 +6,6 @@ use crate::eip712::{build_sign_typed_data_request, build_sign_typed_hash_request
 use crate::error::{WalletError, WalletResult};
 use crate::message::build_sign_message_request;
 
-/// Builds a validated ETH EIP-191 message-signing request.
 pub fn build_eth_eip191_request(
     path: Vec<u32>,
     message: &str,
@@ -16,7 +15,6 @@ pub fn build_eth_eip191_request(
     build_sign_message_request(Chain::Ethereum, path, message, is_hex, chunkify)
 }
 
-/// Builds a validated ETH EIP-712 typed-data request from the full JSON payload.
 pub fn build_eth_eip712_json_request(
     path: Vec<u32>,
     data_json: &str,
@@ -25,7 +23,6 @@ pub fn build_eth_eip712_json_request(
     build_sign_typed_data_request(path, data_json, metamask_v4_compat)
 }
 
-/// Builds a validated ETH EIP-712 typed-data request from pre-hashed inputs.
 pub fn build_eth_eip712_hash_request(
     path: Vec<u32>,
     domain_separator_hash: &str,
@@ -34,8 +31,6 @@ pub fn build_eth_eip712_hash_request(
     build_sign_typed_hash_request(path, domain_separator_hash, message_hash)
 }
 
-/// Builds a validated ETH EIP-712 typed-data request from either full JSON or
-/// pre-hashed inputs.
 pub fn build_eth_eip712_request(
     path: Vec<u32>,
     data_json: Option<&str>,

--- a/crates/thp-core/src/lib.rs
+++ b/crates/thp-core/src/lib.rs
@@ -1,5 +1,3 @@
-//! Core host state machine for the Trezor Host Protocol.
-
 pub mod error;
 pub mod link;
 pub mod session;

--- a/crates/thp-core/src/session.rs
+++ b/crates/thp-core/src/session.rs
@@ -52,7 +52,6 @@ impl ThpSession {
         opts: HandshakeOpts,
         cb: impl Fn(HandshakeEvent) + Send,
     ) -> Result<Self, ThpError> {
-        // Surface a hint to UI that Numeric Comparison may be requested shortly.
         cb(HandshakeEvent::BondingRequired);
 
         let HandshakeOpts {
@@ -82,7 +81,6 @@ impl ThpSession {
         let mut local_msg_id = 0u32;
         let mut remote_msg_id = 1u32;
 
-        // Message 1 (handshake initiation)
         let mut out = vec![0u8; 256];
         let init_payload = app_id.as_deref().unwrap_or(&[]);
         let written = noise.write_message(init_payload, &mut out)?;
@@ -90,7 +88,6 @@ impl ThpSession {
         send_frame(link, mtu, local_msg_id, out).await?;
         local_msg_id = local_msg_id.wrapping_add(2);
 
-        // Message 2 (device response)
         let response = receive_frame(link, &mut decoder, handshake_timeout).await?;
         ensure_msg_id(remote_msg_id, response.msg_id)?;
         remote_msg_id = remote_msg_id.wrapping_add(2);
@@ -110,14 +107,12 @@ impl ThpSession {
             return Err(ThpError::PeerStaticMismatch);
         }
 
-        // Message 3 (handshake completion)
         let mut completion = vec![0u8; 256];
         let len = noise.write_message(&[], &mut completion)?;
         completion.truncate(len);
         send_frame(link, mtu, local_msg_id, completion).await?;
         local_msg_id = local_msg_id.wrapping_add(2);
 
-        // Promote to transport mode.
         let transport = noise.into_transport_mode()?;
 
         let peer = TrustedPeer {
@@ -291,7 +286,6 @@ mod tests {
         let mut decoder = ThpFrameDecoder::new();
         let mut remote_msg_id = 0u32;
 
-        // Receive message 1
         let incoming = receive_frame(&mut link, &mut decoder, Duration::from_secs(1))
             .await
             .unwrap();
@@ -301,14 +295,12 @@ mod tests {
         let read = noise.read_message(&incoming.payload, &mut buf).unwrap();
         buf.truncate(read);
 
-        // Send message 2
         let mut response = vec![0u8; 256];
         let wrote = noise.write_message(&[], &mut response).unwrap();
         response.truncate(wrote);
         let mtu = link.mtu();
         send_frame(&mut link, mtu, 1, response).await.unwrap();
 
-        // Receive message 3
         let incoming = receive_frame(&mut link, &mut decoder, Duration::from_secs(1))
             .await
             .unwrap();
@@ -320,7 +312,6 @@ mod tests {
         let mut transport = noise.into_transport_mode().unwrap();
         let mut next_msg_id = 3u32;
 
-        // Handle one request -> response echo
         loop {
             let incoming = receive_frame(&mut link, &mut decoder, Duration::from_secs(1))
                 .await

--- a/crates/thp-crypto/src/frame.rs
+++ b/crates/thp-crypto/src/frame.rs
@@ -6,7 +6,6 @@ const CRC_LEN: usize = 4;
 const MIN_MTU: usize = HEADER_LEN + CRC_LEN;
 const MAX_PAYLOAD_LEN: usize = 1 << 20; // 1 MiB hard guard for now.
 
-/// Logical THP transport frame.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThpFrame {
     pub msg_id: u32,

--- a/crates/thp-crypto/src/lib.rs
+++ b/crates/thp-crypto/src/lib.rs
@@ -1,5 +1,3 @@
-//! Cryptographic primitives and transport framing for the Trezor Host Protocol.
-
 pub mod frame;
 pub mod noise;
 pub mod traits;

--- a/crates/trezor-connect/examples/ble_handshake.rs
+++ b/crates/trezor-connect/examples/ble_handshake.rs
@@ -1,9 +1,3 @@
-//! Demonstrates how to drive the BLE THP workflow by scanning and connecting
-//! to a nearby Trezor Safe 7 device.
-//!
-//! Requires the `ble` feature to be enabled:
-//! `cargo run -p trezor-connect --example ble_handshake --features ble`
-
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
@@ -14,7 +8,6 @@ use trezor_connect::thp::types::{HostConfig, PairingMethod};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Discover devices
     let profile =
         BleProfile::trezor_safe7().ok_or_else(|| anyhow!("trezor_safe7 profile not enabled"))?;
     let manager = ble_transport::BleManager::new().await?;
@@ -32,7 +25,6 @@ async fn main() -> Result<()> {
     let info = device.info();
     println!("Connecting to {} ({:?})", info.id, info.name);
 
-    // Open a BLE session and drive the workflow.
     let (info, peripheral) = device.into_parts();
     let session = BleSession::new(peripheral, profile, info)
         .await

--- a/crates/trezor-connect/src/ble.rs
+++ b/crates/trezor-connect/src/ble.rs
@@ -58,6 +58,47 @@ const MESSAGE_TYPE_BUTTON_ACK: u16 = messages::ThpMessageType::ButtonAck as i32 
 const MIN_THP_FRAME_SIZE: usize = 9; // 1 magic + 2 channel + 2 len + 4 crc
 const THP_CONTROL_BITS_MASK: u8 = (1 << 3) | (1 << 4);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RecentReplayableResponse {
+    magic: u8,
+    crc: [u8; 4],
+}
+
+fn is_replayable_request_magic(magic: u8) -> bool {
+    matches!(
+        magic,
+        MAGIC_HANDSHAKE_INIT_REQUEST | MAGIC_HANDSHAKE_COMPLETION_REQUEST | MAGIC_CONTROL_ENCRYPTED
+    )
+}
+
+fn is_replayable_response_magic(magic: u8) -> bool {
+    matches!(
+        magic,
+        wire::MAGIC_HANDSHAKE_INIT_RESPONSE
+            | wire::MAGIC_HANDSHAKE_COMPLETION_RESPONSE
+            | wire::MAGIC_CONTROL_ENCRYPTED
+            | wire::MAGIC_CONTROL_DECRYPTED
+    )
+}
+
+fn should_replay_recent_request(
+    parsed: &ParsedMessage,
+    state: &ThpWireState,
+    recent: Option<RecentReplayableResponse>,
+) -> bool {
+    is_replayable_response_magic(parsed.header.magic)
+        && parsed.header.seq_bit != state.recv_bit()
+        && recent
+            .is_some_and(|recent| recent.magic == parsed.header.magic && recent.crc == parsed.crc)
+}
+
+fn should_ack_magic(magic: u8) -> bool {
+    !matches!(
+        magic,
+        MAGIC_CREATE_CHANNEL_RESPONSE | wire::MAGIC_READ_ACK | wire::MAGIC_ERROR
+    )
+}
+
 #[derive(Clone, PartialEq, Message)]
 struct FailureProto {
     #[prost(int32, optional, tag = "1")]
@@ -401,6 +442,8 @@ pub struct BleBackend {
     rx_buffer: Vec<u8>,
     continuation: Vec<u8>,
     pending_chunk: Option<ChunkAccumulator>,
+    last_sent_sync_frame: Option<Vec<u8>>,
+    recent_response: Option<RecentReplayableResponse>,
 }
 
 impl BleBackend {
@@ -414,6 +457,8 @@ impl BleBackend {
             rx_buffer: Vec::new(),
             continuation: Vec::new(),
             pending_chunk: None,
+            last_sent_sync_frame: None,
+            recent_response: None,
         }
     }
 
@@ -461,6 +506,9 @@ impl BleBackend {
         } else {
             debug!("BLE THP TX frame: magic=0x{magic:02x} len={}", frame.len());
         }
+        if is_replayable_request_magic(base_magic) {
+            self.last_sent_sync_frame = Some(frame.clone());
+        }
         let mtu = {
             let link = self.inner.link_mut();
             link.mtu()
@@ -496,8 +544,9 @@ impl BleBackend {
             Ok(decoded) => {
                 self.rx_buffer.drain(..decoded.consumed);
                 trim_zero_padding(&mut self.rx_buffer);
+                let crc = decoded.crc;
                 let parsed =
-                    wire::parse_response(decoded.message).map_err(Self::transport_error)?;
+                    wire::parse_response(decoded.message, crc).map_err(Self::transport_error)?;
                 Ok(Some(parsed))
             }
             Err(WireError::ShortPacket) => Ok(None),
@@ -548,9 +597,41 @@ impl BleBackend {
         }
     }
 
+    fn remember_recent_response(&mut self, parsed: &ParsedMessage) {
+        if is_replayable_response_magic(parsed.header.magic) {
+            self.recent_response = Some(RecentReplayableResponse {
+                magic: parsed.header.magic,
+                crc: parsed.crc,
+            });
+        }
+    }
+
     async fn read_next(&mut self) -> BackendResult<ParsedMessage> {
         loop {
             if let Some(mut parsed) = self.try_parse()? {
+                if should_replay_recent_request(&parsed, &self.state, self.recent_response) {
+                    debug!(
+                        magic = format_args!("0x{:02x}", parsed.header.magic),
+                        expected_seq = self.state.recv_bit(),
+                        got_seq = parsed.header.seq_bit,
+                        "BLE THP retransmitted recent response; re-ACKing and replaying last outbound"
+                    );
+                    self.send_ack_with_bit(parsed.header.seq_bit).await?;
+                    if let Some(frame) = self.last_sent_sync_frame.clone() {
+                        self.send_frame(frame).await?;
+                    }
+                    continue;
+                }
+                if is_replayable_response_magic(parsed.header.magic)
+                    && parsed.header.seq_bit != self.state.recv_bit()
+                {
+                    return Err(BackendError::Transport(format!(
+                        "unexpected seq bit {} for THP frame 0x{:02x}; expected {}",
+                        parsed.header.seq_bit,
+                        parsed.header.magic,
+                        self.state.recv_bit()
+                    )));
+                }
                 match &mut parsed.response {
                     WireResponse::Ack => continue,
                     WireResponse::Continuation(chunk) => {
@@ -563,6 +644,7 @@ impl BleBackend {
                             merged.extend(payload.iter());
                             *payload = merged;
                         }
+                        self.remember_recent_response(&parsed);
                         return Ok(parsed);
                     }
                     _ => {
@@ -576,6 +658,7 @@ impl BleBackend {
                         if self.should_ack(&parsed.header) {
                             self.send_ack(&parsed.header).await?;
                         }
+                        self.remember_recent_response(&parsed);
                         return Ok(parsed);
                     }
                 }
@@ -689,10 +772,12 @@ impl BleBackend {
     }
 
     async fn send_ack(&mut self, _header: &wire::WireHeader) -> BackendResult<()> {
-        let ack_bit = self.state.recv_ack_bit();
+        self.send_ack_with_bit(self.state.recv_ack_bit()).await
+    }
+
+    async fn send_ack_with_bit(&mut self, ack_bit: u8) -> BackendResult<()> {
         let frame = wire::encode_ack(self.state.channel(), ack_bit);
-        self.send_frame(frame).await?;
-        Ok(())
+        self.send_frame(frame).await
     }
 
     async fn send_encrypted_request(&mut self, encoded: EncodedMessage) -> BackendResult<()> {
@@ -826,10 +911,7 @@ impl BleBackend {
     }
 
     fn should_ack(&self, header: &wire::WireHeader) -> bool {
-        !matches!(
-            header.magic,
-            MAGIC_CREATE_CHANNEL_RESPONSE | wire::MAGIC_READ_ACK
-        )
+        should_ack_magic(header.magic)
     }
 }
 

--- a/crates/trezor-connect/src/ble.rs
+++ b/crates/trezor-connect/src/ble.rs
@@ -75,7 +75,6 @@ struct ChunkAccumulator {
 
 impl ChunkAccumulator {
     fn start(chunk: &[u8]) -> Option<Self> {
-        // A valid THP V2 first chunk needs: magic (1) + channel (2) + len (2).
         if chunk.len() < 5 {
             return None;
         }
@@ -766,7 +765,6 @@ impl BleBackend {
         }
     }
 
-    /// Send a pairing tag and receive the parsed tag response.
     async fn send_and_receive_tag(
         &mut self,
         encoded: EncodedMessage,
@@ -785,8 +783,6 @@ impl BleBackend {
         .await
     }
 
-    /// Read and decrypt the next meaningful device message, handling ACK,
-    /// ButtonRequest, and Failure automatically.
     async fn read_signing_message(&mut self) -> BackendResult<(u16, Vec<u8>)> {
         loop {
             let parsed = self.read_next().await?;

--- a/crates/trezor-connect/src/ble/backend_impl.rs
+++ b/crates/trezor-connect/src/ble/backend_impl.rs
@@ -125,7 +125,6 @@ impl ThpBackend for BleBackend {
                 host_pairing_credential,
             };
             let mut buf = Vec::new();
-            // prost encode to Vec<u8> is infallible (no I/O, only OOM which panics anyway)
             message
                 .encode(&mut buf)
                 .expect("encode to Vec is infallible");
@@ -201,8 +200,6 @@ impl ThpBackend for BleBackend {
                 self.state.on_receive(parsed.header.magic);
                 self.state.set_expected_responses(&[]);
 
-                // Handshake completion response is AES-GCM encrypted with key_response,
-                // nonce 0, empty associated data and a single-byte plaintext state.
                 let key = self.trezor_key()?;
                 let iv = [0u8; 12];
                 let plaintext = aes256gcm_decrypt(&key, &iv, &[], &[encrypted_state], &tag)
@@ -384,7 +381,6 @@ impl ThpBackend for BleBackend {
                     Ok(response) => response,
                 };
 
-                // Validation requires stored NFC secret; not available here, so defer to workflow.
                 Ok(to_pairing_tag_response(response))
             }
             PairingTagRequest::CodeEntry {
@@ -535,8 +531,7 @@ impl ThpBackend for BleBackend {
         };
 
         if request.include_public_key {
-            // Keep public-key retrieval silent. Address confirmation is handled by GetAddress
-            // itself; mirroring Suite behavior avoids extra on-device prompts/failures.
+            // Mirror Suite: keep GetPublicKey silent to avoid extra prompts.
             let encoded = encode_get_public_key_request(request.chain, &request.path, false)
                 .map_err(Self::transport_error)?;
             self.send_encrypted_request(encoded).await?;
@@ -749,16 +744,7 @@ impl ThpBackend for BleBackend {
                 })?;
                 let ref_txs_by_hash = build_ref_txs_index(&btc);
                 let orig_txs_by_hash = build_orig_txs_index(&btc);
-                // Collect per-input signatures, indexed by the device's
-                // `signature_index`. The Bitcoin signing flow streams one
-                // signature per signed input; keeping only the latest is
-                // incorrect for multi-input transactions, where each input
-                // has a distinct sighash and therefore a distinct signature.
                 let mut signatures: Vec<Vec<u8>> = Vec::new();
-                // Fallback for flows that deliver a signature without a
-                // `signature_index` (e.g. on TXFINISHED from older firmware).
-                // Keeps `SignTxResponse.r` populated for single-signature
-                // consumers that still read the legacy field.
                 let mut last_signature: Option<Vec<u8>> = None;
 
                 loop {
@@ -795,11 +781,7 @@ impl ThpBackend for BleBackend {
                         }
                         BitcoinTxRequestHandling::Finished => {
                             self.state.set_expected_responses(&[]);
-                            // Preserve the legacy `r` field: prefer the last
-                            // indexed signature (current multi-input flow),
-                            // and fall back to any un-indexed signature seen
-                            // (legacy single-signature flow). New consumers
-                            // should prefer the `signatures` vector.
+                            // Legacy fallback: prefer last indexed signature for 'r'.
                             let r = signatures
                                 .last()
                                 .cloned()

--- a/crates/trezor-connect/src/ble/tests.rs
+++ b/crates/trezor-connect/src/ble/tests.rs
@@ -402,6 +402,53 @@ fn thp_v2_chunk_reassembly_recovers_after_bad_continuation() {
     assert_eq!(reassembled.as_deref(), Some(frame2.as_slice()));
 }
 
+fn parsed_message(magic: u8, seq_bit: u8, crc: [u8; 4]) -> ParsedMessage {
+    ParsedMessage {
+        header: wire::WireHeader {
+            raw_magic: magic | (seq_bit << 4),
+            magic,
+            ack_bit: 0,
+            seq_bit,
+            channel: 0x1234,
+        },
+        response: WireResponse::Ack,
+        crc,
+    }
+}
+
+#[test]
+fn recent_replayable_response_requires_matching_magic_and_crc() {
+    let mut state = ThpWireState::new();
+    state.on_receive(wire::MAGIC_CONTROL_ENCRYPTED);
+
+    let recent = Some(RecentReplayableResponse {
+        magic: wire::MAGIC_CONTROL_ENCRYPTED,
+        crc: [1, 2, 3, 4],
+    });
+    let duplicate = parsed_message(wire::MAGIC_CONTROL_ENCRYPTED, 0, [1, 2, 3, 4]);
+    let wrong_crc = parsed_message(wire::MAGIC_CONTROL_ENCRYPTED, 0, [4, 3, 2, 1]);
+    let wrong_magic = parsed_message(wire::MAGIC_HANDSHAKE_INIT_RESPONSE, 0, [1, 2, 3, 4]);
+
+    assert!(should_replay_recent_request(&duplicate, &state, recent));
+    assert!(!should_replay_recent_request(&wrong_crc, &state, recent));
+    assert!(!should_replay_recent_request(&wrong_magic, &state, recent));
+}
+
+#[test]
+fn error_frames_are_never_replayed_or_acked() {
+    let mut state = ThpWireState::new();
+    state.on_receive(wire::MAGIC_CONTROL_ENCRYPTED);
+
+    let recent = Some(RecentReplayableResponse {
+        magic: wire::MAGIC_ERROR,
+        crc: [9, 9, 9, 9],
+    });
+    let error = parsed_message(wire::MAGIC_ERROR, 0, [9, 9, 9, 9]);
+
+    assert!(!should_replay_recent_request(&error, &state, recent));
+    assert!(!should_ack_magic(wire::MAGIC_ERROR));
+}
+
 fn hex_to_bytes(s: &str) -> Vec<u8> {
     let stripped = s.strip_prefix("0x").unwrap_or(s);
     if stripped.is_empty() {

--- a/crates/trezor-connect/src/thp/crypto/curve25519.rs
+++ b/crates/trezor-connect/src/thp/crypto/curve25519.rs
@@ -208,7 +208,6 @@ pub fn elligator2(input: &[u8; 32]) -> [u8; 32] {
     tv2 = mod_reduce(&y1 * &y1, p);
     tv2 = mod_reduce(&tv2 * &gxd, p);
     let e3 = tv2 == gx1;
-    // conditionalMove(x2n, x1n, e3): choose x1n when e3 is true, otherwise x2n.
     let xn = if e3 { x1n.clone() } else { x2n };
     let xd_inv = pow_mod(&xd, &(p - BigInt::from(2u8)), p);
     let x = mod_reduce(&xn * xd_inv, p);
@@ -244,7 +243,6 @@ mod tests {
             rng.fill(&mut private_key);
             let mut u_coordinate = [0u8; 32];
             rng.fill(&mut u_coordinate);
-            // RFC7748 decodeUCoordinate ignores the top bit.
             u_coordinate[31] &= 0x7f;
 
             let ours = curve25519(&private_key, &u_coordinate);
@@ -258,7 +256,7 @@ mod tests {
 
     #[test]
     fn elligator2_matches_trezor_suite_fixtures() {
-        // Copied from trezor-suite packages/protocol/tests/protocol-thp/curve25519.fixtures.ts
+        // Fixtures copied from trezor-suite packages/protocol/tests/protocol-thp/curve25519.fixtures.ts.
         let fixtures = [
             (
                 "0000000000000000000000000000000000000000000000000000000000000000",

--- a/crates/trezor-connect/src/thp/crypto/pairing.rs
+++ b/crates/trezor-connect/src/thp/crypto/pairing.rs
@@ -245,8 +245,6 @@ pub fn get_cpace_host_keys<R: Rng + CryptoRng>(
 }
 
 pub fn get_shared_secret(public_key: &[u8; 32], private_key: &[u8; 32]) -> [u8; 32] {
-    // Match Trezor Suite implementation exactly: shared_secret = X25519(private, public),
-    // then tag = SHA-256(shared_secret).
     let secret = curve25519(private_key, public_key);
     sha256(&secret)
 }
@@ -484,7 +482,6 @@ mod tests {
 
         let keys = get_cpace_host_keys(code, &handshake_hash, &mut rng);
 
-        // Derive the generator deterministically per spec.
         let mut sha = Sha512::new();
         sha.update([0x08, 0x43, 0x50, 0x61, 0x63, 0x65, 0x32, 0x35, 0x35, 0x06]);
         sha.update(code);

--- a/crates/trezor-connect/src/thp/crypto/tools.rs
+++ b/crates/trezor-connect/src/thp/crypto/tools.rs
@@ -21,7 +21,6 @@ pub(super) fn hash_of_two(first: &[u8], second: &[u8]) -> [u8; 32] {
 }
 
 pub(super) fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
-    // HMAC-SHA256 accepts any key length per RFC 2104
     let mut ctx =
         <HmacSha256 as hmac::KeyInit>::new_from_slice(key).expect("HMAC accepts any key size");
     ctx.update(data);
@@ -31,7 +30,6 @@ pub(super) fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
 pub(super) fn hkdf(chaining_key: &[u8], input: &[u8]) -> ([u8; 32], [u8; 32]) {
     let temp_key = hmac_sha256(chaining_key, input);
     let output1 = hmac_sha256(&temp_key, &[0x01]);
-    // HMAC-SHA256 accepts any key length per RFC 2104
     let mut ctx = <HmacSha256 as hmac::KeyInit>::new_from_slice(&temp_key)
         .expect("HMAC accepts any key size");
     ctx.update(&output1);

--- a/crates/trezor-connect/src/thp/proto/bitcoin.rs
+++ b/crates/trezor-connect/src/thp/proto/bitcoin.rs
@@ -20,7 +20,6 @@ pub const MESSAGE_TYPE_BITCOIN_MESSAGE_SIGNATURE: u16 = 40;
 pub const MESSAGE_TYPE_BITCOIN_SIGN_TX: u16 = 15;
 pub const MESSAGE_TYPE_BITCOIN_TX_REQUEST: u16 = 21;
 pub const MESSAGE_TYPE_BITCOIN_TX_ACK: u16 = 22;
-/// `TxAckPaymentRequest` — sent in response to a `TXPAYMENTREQ` firmware request.
 pub const MESSAGE_TYPE_BITCOIN_TX_ACK_PAYMENT_REQUEST: u16 = 37;
 
 #[derive(Clone, PartialEq, Message)]
@@ -228,9 +227,6 @@ struct BitcoinTxAckTransaction {
     branch_id: Option<u32>,
 }
 
-// ── Multisig proto structs ───────────────────────────────────────────────────
-
-/// Matches Trezor's `HDNodeType` from `messages-common.proto`.
 #[derive(Clone, PartialEq, Message)]
 struct ProtoHDNodeType {
     #[prost(uint32, required, tag = "1")]
@@ -247,7 +243,6 @@ struct ProtoHDNodeType {
     public_key: Vec<u8>,
 }
 
-/// Matches `MultisigRedeemScriptType.HDNodePathType`.
 #[derive(Clone, PartialEq, Message)]
 struct ProtoHDNodePathType {
     #[prost(message, required, tag = "1")]
@@ -256,30 +251,21 @@ struct ProtoHDNodePathType {
     address_n: Vec<u32>,
 }
 
-/// Matches Trezor's `MultisigRedeemScriptType` from `messages-bitcoin.proto`.
 #[derive(Clone, PartialEq, Message)]
 struct ProtoMultisigRedeemScriptType {
-    /// Deprecated pubkeys-with-paths (use `nodes` + `address_n` instead).
     #[prost(message, repeated, tag = "1")]
     pubkeys: Vec<ProtoHDNodePathType>,
-    /// Existing partial signatures (empty bytes = missing).
     #[prost(bytes = "vec", repeated, tag = "2")]
     signatures: Vec<Vec<u8>>,
-    /// Required threshold (`m` in m-of-n).
     #[prost(uint32, required, tag = "3")]
     m: u32,
-    /// Cosigner HD nodes (preferred flat representation).
     #[prost(message, repeated, tag = "4")]
     nodes: Vec<ProtoHDNodeType>,
-    /// Common derivation suffix applied to every node in `nodes`.
     #[prost(uint32, repeated, packed = "false", tag = "5")]
     address_n: Vec<u32>,
-    /// Ordering policy for `pubkeys`.
     #[prost(enumeration = "ProtoMultisigPubkeysOrder", optional, tag = "6")]
     pubkeys_order: Option<i32>,
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, prost::Enumeration)]
 #[repr(i32)]
@@ -367,8 +353,6 @@ enum BitcoinOutputScriptTypeProto {
     PayToTaproot = 6,
 }
 
-// ── TxAckPaymentRequest proto structs ────────────────────────────────────────
-
 #[derive(Clone, PartialEq, Message)]
 struct ProtoTextMemo {
     #[prost(string, optional, tag = "1")]
@@ -432,8 +416,6 @@ struct ProtoTxAckPaymentRequest {
     #[prost(bytes = "vec", required, tag = "5")]
     signature: Vec<u8>,
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
 
 pub(super) fn encode_get_address_request(
     request: &GetAddressRequest,
@@ -968,12 +950,6 @@ pub fn encode_bitcoin_tx_ack_prev_extra_data(
     })
 }
 
-/// Encodes a `TxAckPaymentRequest` response to a firmware `TXPAYMENTREQ` request.
-///
-/// The firmware sends `TxRequest { type: TXPAYMENTREQ, details.request_index: N }` and
-/// expects the host to reply with the payment-request data at index N from the caller-
-/// supplied list.  Most signing flows have no payment requests; this encoder is only
-/// invoked when the firmware explicitly asks for one.
 pub fn encode_bitcoin_tx_ack_payment_request(
     pr: &BtcPaymentRequest,
 ) -> Result<EncodedMessage, ProtoMappingError> {

--- a/crates/trezor-connect/src/thp/transport.rs
+++ b/crates/trezor-connect/src/thp/transport.rs
@@ -14,7 +14,6 @@ pub enum TransportError {
     NoSession,
 }
 
-/// Maintains a THP session lifecycle for a given link.
 #[derive(Default)]
 pub struct ThpTransport {
     session: Option<ThpSession>,

--- a/crates/trezor-connect/src/thp/types.rs
+++ b/crates/trezor-connect/src/thp/types.rs
@@ -400,7 +400,6 @@ pub struct EthAccessListEntry {
     pub storage_keys: Vec<Vec<u8>>,
 }
 
-/// A BIP-32 HD node in deserialized form, matching Trezor's `HDNodeType` protobuf message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BtcHDNode {
     pub depth: u32,
@@ -410,8 +409,6 @@ pub struct BtcHDNode {
     pub public_key: Vec<u8>,
 }
 
-/// An HD node together with a relative BIP-32 derivation suffix,
-/// matching Trezor's `HDNodePathType` (nested inside `MultisigRedeemScriptType`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BtcHDNodePath {
     pub node: BtcHDNode,
@@ -424,23 +421,13 @@ pub enum BtcMultisigPubkeysOrder {
     Lexicographic,
 }
 
-/// Multisig cosigner metadata sent alongside `SpendMultisig` inputs
-/// and `PayToMultisig` outputs.  Matches Trezor's `MultisigRedeemScriptType`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BtcMultisig {
-    /// Cosigner HD nodes with their derivation suffixes (deprecated path —
-    /// prefer setting `nodes` + `address_n` instead, but both are supported).
     pub pubkeys: Vec<BtcHDNodePath>,
-    /// Existing partial signatures in order.  Empty `Vec<u8>` entries denote
-    /// missing signatures.
     pub signatures: Vec<Vec<u8>>,
-    /// Required signature threshold (`m` of m-of-n).
     pub m: u32,
-    /// Cosigner HD nodes (preferred flat representation).
     pub nodes: Vec<BtcHDNode>,
-    /// Common derivation suffix applied to every node in `nodes`.
     pub address_n: Vec<u32>,
-    /// Ordering policy for `pubkeys` when constructing the redeem script.
     pub pubkeys_order: BtcMultisigPubkeysOrder,
 }
 
@@ -535,20 +522,20 @@ pub struct BtcOrigTx {
     pub branch_id: Option<u32>,
 }
 
-/// A single memo attached to a payment request.
 #[derive(Debug, Clone)]
 pub enum BtcPaymentRequestMemo {
-    /// Plain-text human-readable note shown to the user.
-    Text { text: String },
-    /// Plain-text heading and details shown together.
-    TextDetails { title: String, text: String },
-    /// Refund address in case the payment cannot be fulfilled.
+    Text {
+        text: String,
+    },
+    TextDetails {
+        title: String,
+        text: String,
+    },
     Refund {
         address: String,
         path: Vec<u32>,
         mac: Vec<u8>,
     },
-    /// Coin-purchase details (exchange / swap flows).
     CoinPurchase {
         coin_type: u32,
         amount: String,
@@ -558,37 +545,23 @@ pub enum BtcPaymentRequestMemo {
     },
 }
 
-/// Encoded SLIP-24 payment request amount.
-///
-/// The firmware expects little-endian bytes, typically 8 bytes for Bitcoin.
+/// SLIP-24-encoded payment request amount bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BtcPaymentRequestAmount(pub Vec<u8>);
 
 impl BtcPaymentRequestAmount {
-    /// Encodes a Bitcoin amount as 8-byte little-endian satoshis.
     pub fn from_sats(amount: u64) -> Self {
         Self(amount.to_le_bytes().to_vec())
     }
 }
 
-/// Represents a `TxAckPaymentRequest` value carried by the caller and returned
-/// to the firmware when it sends a `TxRequest` with type `TXPAYMENTREQ`.
-///
-/// Payment requests implement a Trezor-internal BIP-70 successor protocol.
-/// For most signing flows this list will be empty; the field exists so that
-/// callers who do need payment-request support can supply the data without a
-/// separate API change.
+/// Caller-supplied SLIP-24 payment request data for `TXPAYMENTREQ`.
 #[derive(Debug, Clone)]
 pub struct BtcPaymentRequest {
-    /// Random nonce supplied by the recipient (anti-replay).
     pub nonce: Option<Vec<u8>>,
-    /// Human-readable merchant / recipient name.
     pub recipient_name: String,
-    /// Optional structured memos (text, refund, coin-purchase).
     pub memos: Vec<BtcPaymentRequestMemo>,
-    /// Encoded payment amount bytes as defined by SLIP-24.
     pub amount: Option<BtcPaymentRequestAmount>,
-    /// Recipient's signature over the serialised request.
     pub signature: Vec<u8>,
 }
 
@@ -600,8 +573,6 @@ pub struct BtcSignTx {
     pub outputs: Vec<BtcSignOutput>,
     pub ref_txs: Vec<BtcRefTx>,
     pub orig_txs: Vec<BtcOrigTx>,
-    /// Payment requests indexed by the `request_index` field in `TxRequest`.
-    /// Most signing flows leave this empty.
     pub payment_reqs: Vec<BtcPaymentRequest>,
     pub chunkify: bool,
 }
@@ -730,12 +701,7 @@ pub struct SignTxResponse {
     pub v: u32,
     pub r: Vec<u8>,
     pub s: Vec<u8>,
-    /// Per-input signatures collected during transaction signing,
-    /// indexed by the device's `signature_index`.
-    ///
-    /// Currently populated for Bitcoin signing, where the device streams
-    /// one signature per input; empty for Ethereum and Solana, which
-    /// produce a single signature exposed via `r`/`s`.
+    /// Per-input Bitcoin signatures, indexed by the device's `signature_index`.
     pub signatures: Vec<Vec<u8>>,
 }
 

--- a/crates/trezor-connect/src/thp/wire.rs
+++ b/crates/trezor-connect/src/thp/wire.rs
@@ -312,6 +312,7 @@ pub fn encode_create_channel_request(nonce: &[u8; 8]) -> Vec<u8> {
 pub struct DecodedFrame {
     pub message: WireMessage,
     pub consumed: usize,
+    pub crc: [u8; CRC_LENGTH],
 }
 
 pub fn decode_frame(data: &[u8], expected_channel: Option<u16>) -> Result<DecodedFrame, WireError> {
@@ -344,6 +345,7 @@ pub fn decode_frame(data: &[u8], expected_channel: Option<u16>) -> Result<Decode
     if computed.finalize().to_be_bytes() != crc {
         return Err(WireError::CrcMismatch);
     }
+    let crc = crc.try_into().expect("CRC length is fixed");
     let ack_bit = if raw_magic & ACK_BIT > 0 { 1 } else { 0 };
     let seq_bit = if raw_magic & SEQ_BIT > 0 { 1 } else { 0 };
     let magic = clear_control_bits(raw_magic);
@@ -357,15 +359,20 @@ pub fn decode_frame(data: &[u8], expected_channel: Option<u16>) -> Result<Decode
     Ok(DecodedFrame {
         message: WireMessage { header, payload },
         consumed: payload_end + CRC_LENGTH,
+        crc,
     })
 }
 
 pub struct ParsedMessage {
     pub header: WireHeader,
     pub response: WireResponse,
+    pub crc: [u8; CRC_LENGTH],
 }
 
-pub fn parse_response(message: WireMessage) -> Result<ParsedMessage, WireError> {
+pub fn parse_response(
+    message: WireMessage,
+    crc: [u8; CRC_LENGTH],
+) -> Result<ParsedMessage, WireError> {
     let header = message.header.clone();
     let response = match message.header.magic {
         MAGIC_CREATE_CHANNEL_RESPONSE => {
@@ -432,7 +439,11 @@ pub fn parse_response(message: WireMessage) -> Result<ParsedMessage, WireError> 
         }
         other => return Err(WireError::UnexpectedMagic(other)),
     };
-    Ok(ParsedMessage { header, response })
+    Ok(ParsedMessage {
+        header,
+        response,
+        crc,
+    })
 }
 
 pub fn encode_handshake_init_request(
@@ -502,7 +513,8 @@ mod tests {
         let decoded = decode_frame(&frame, None).expect("decode frame");
         assert_eq!(decoded.consumed, frame.len());
 
-        let parsed = parse_response(decoded.message).expect("parse response");
+        let crc = decoded.crc;
+        let parsed = parse_response(decoded.message, crc).expect("parse response");
         assert_eq!(parsed.header.magic, MAGIC_CREATE_CHANNEL_RESPONSE);
         match parsed.response {
             WireResponse::CreateChannel {
@@ -530,7 +542,8 @@ mod tests {
         let header = WireHeader::new(MAGIC_READ_ACK, 0x0042, 1, 0);
         let frame = encode_frame(header, &[]);
         let decoded = decode_frame(&frame, Some(0x0042)).expect("decode");
-        let parsed = parse_response(decoded.message).expect("parse");
+        let crc = decoded.crc;
+        let parsed = parse_response(decoded.message, crc).expect("parse");
         assert!(matches!(parsed.response, WireResponse::Ack));
     }
 
@@ -539,7 +552,8 @@ mod tests {
         let header = WireHeader::new(MAGIC_HANDSHAKE_COMPLETION_RESPONSE, 0x0042, 0, 0);
         let frame = encode_frame(header, &[0xAA; 1]);
         let decoded = decode_frame(&frame, Some(0x0042)).expect("decode");
-        match parse_response(decoded.message) {
+        let crc = decoded.crc;
+        match parse_response(decoded.message, crc) {
             Err(WireError::ShortPacket) => {}
             Err(other) => panic!("unexpected error: {other}"),
             Ok(_) => panic!("short payload should fail"),
@@ -608,7 +622,8 @@ mod tests {
         let response_header = WireHeader::new(MAGIC_CREATE_CHANNEL_RESPONSE, DEFAULT_CHANNEL, 0, 0);
         let frame = encode_frame(response_header, &payload);
         let decoded = decode_frame(&frame, None).expect("decode frame");
-        let parsed = parse_response(decoded.message).expect("parse response");
+        let crc = decoded.crc;
+        let parsed = parse_response(decoded.message, crc).expect("parse response");
         state.on_receive(parsed.header.magic);
         state.set_expected_responses(&[]);
         assert_eq!(state.recv_bit(), 0); // create-channel does not toggle sync bits
@@ -649,7 +664,8 @@ mod tests {
         let init_header = WireHeader::new(MAGIC_HANDSHAKE_INIT_RESPONSE, state.channel(), 0, 0);
         let frame = encode_frame(init_header, &init_payload);
         let decoded = decode_frame(&frame, Some(state.channel())).expect("decode init frame");
-        let parsed = parse_response(decoded.message).expect("parse init response");
+        let crc = decoded.crc;
+        let parsed = parse_response(decoded.message, crc).expect("parse init response");
         state.on_receive(parsed.header.magic);
         state.set_expected_responses(&[]);
         assert_eq!(state.recv_bit(), 1);
@@ -667,7 +683,8 @@ mod tests {
         );
 
         let decoded = decode_frame(&completion_frame, Some(state.channel())).unwrap();
-        let parsed = parse_response(decoded.message).unwrap();
+        let crc = decoded.crc;
+        let parsed = parse_response(decoded.message, crc).unwrap();
         state.on_receive(parsed.header.magic);
         state.set_expected_responses(&[]);
         assert_eq!(state.recv_bit(), 0);

--- a/crates/trezor-connect/src/thp/workflow.rs
+++ b/crates/trezor-connect/src/thp/workflow.rs
@@ -152,7 +152,6 @@ where
 
         let outcome = self.backend.handshake_init(request).await?;
 
-        // Extract fields needed for the completion request before moving outcome.
         let completion_request = HandshakeCompletionRequest {
             host_pubkey: outcome.host_encrypted_static_pubkey.clone(),
             encrypted_payload: outcome.encrypted_payload,
@@ -207,8 +206,7 @@ where
                 self.state.set_phase(Phase::Pairing);
             }
             HandshakeCompletionState::Paired => {
-                // Mirror Suite behavior: paired handshake completion still requires
-                // connection finalization (credential request + end request).
+                // Mirror Suite: paired handshake completion still needs finalization.
                 self.state.set_is_paired(true);
                 self.state.set_phase(Phase::Pairing);
             }
@@ -296,10 +294,7 @@ where
         'pairing_flow: loop {
             match select_response {
                 super::types::SelectMethodResponse::End => {
-                    // The firmware already sent ThpEndResponse and exited the
-                    // pairing context (e.g. SkipPairing).  No need to send
-                    // ThpEndRequest — doing so would hit a Failure because the
-                    // pairing handler is no longer running.
+                    // Firmware already exited pairing context; no end_request needed.
                     self.state.set_is_paired(true);
                     self.state.set_phase(Phase::Paired);
                     return Ok(());

--- a/skills/comments.md
+++ b/skills/comments.md
@@ -16,19 +16,16 @@ counter += 1;
 
 ## Doc Comments
 
-Use `///` on all public types, traits, and functions in library crates. FFI-exported methods (`#[uniffi::export]`) must have doc comments since they define the API surface for iOS/Android consumers.
+Comments and doc comments are optional by default. When they add value, keep them to a single line. Public APIs do not need blanket `///` coverage; add a short doc comment only when it materially improves the consumer-facing surface (for example CLI help or FFI bindings).
 
 ```rust
 /// Scan for BLE devices matching the configured profile.
-///
-/// Returns a stream of discovered devices. The scan stops when
-/// the returned `ScanHandle` is dropped.
 pub fn scan(&self) -> ScanHandle { ... }
 ```
 
 ## Safety and Invariant Comments
 
-When an `unwrap()` or `expect()` is provably safe, add a comment explaining why:
+When an `unwrap()` or `expect()` is provably safe, add a one-line comment explaining why:
 
 ```rust
 // SAFETY: & 0xFF guarantees the value is in [0, 255], always valid for u8.


### PR DESCRIPTION
This change replaces the broad seq-bit replay logic with Suite-aligned duplicate detection.

What changed:
- cache only replayable outbound THP requests
- remember the last accepted replayable response by `(magic, crc)`
- replay only when a retransmitted response matches that recent `(magic, crc)` pair
- treat other replayable seq-bit mismatches as transport errors
- exclude `MAGIC_ERROR` from replay and ACK handling

Why:
- avoids replaying the last request when the device retransmits an error frame
- narrows retransmit recovery to confirmed duplicates instead of every sync-toggling frame
- matches the Trezor Suite transport model more closely

Verification:
- `just fmt && just lint`
- `cargo test -p trezor-connect --lib --tests --features ble`

Context:
- alternative to PR #59's broader retransmit replay approach
- stacked on `h/simplify-code-comments`
