### PR TITLE
Roll up crypto and UniFFI dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,14 +13,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -29,11 +50,25 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
  "subtle",
 ]
 
@@ -110,11 +145,11 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "askama"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
- "askama_derive",
+ "askama_macros",
  "itoa",
  "percent-encoding",
  "serde",
@@ -123,12 +158,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
  "askama_parser",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -139,15 +175,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama_parser"
-version = "0.14.0"
+name = "askama_macros"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
- "memchr",
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+dependencies = [
+ "rustc-hash",
  "serde",
  "serde_derive",
- "winnow",
+ "unicode-ident",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -365,18 +411,19 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -415,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -436,9 +483,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -450,8 +497,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -529,6 +587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,17 +644,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -599,7 +664,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -718,7 +792,7 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -774,7 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -825,9 +899,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fs-err"
-version = "2.11.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
@@ -975,7 +1049,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.1",
 ]
 
 [[package]]
@@ -1167,6 +1250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1371,7 +1463,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1559,7 +1651,7 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -1571,7 +1663,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -1930,7 +2033,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2162,7 +2265,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599b506ccc4aff8cf7844bc42cf783009a434c1e26c964432560fb6d6ad02d82"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "blake2",
  "chacha20poly1305",
  "curve25519-dalek",
@@ -2235,10 +2338,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2308,7 +2411,7 @@ dependencies = [
 name = "thp-crypto"
 version = "0.1.1"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.0",
  "crc32fast",
  "hex",
  "hkdf",
@@ -2415,7 +2518,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -2433,7 +2536,7 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -2518,7 +2621,7 @@ dependencies = [
 name = "trezor-connect"
 version = "0.1.1"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.0",
  "anyhow",
  "async-trait",
  "ble-transport",
@@ -2570,9 +2673,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
+checksum = "a782a48d72cfd7a2d65cfc7c691dbf5375c43104b3c195f7eccc716dcc3540c8"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2584,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
+checksum = "533b0312c73e3b54eb78a4b257ceae390962dd4767995778309a74644643f9ac"
 dependencies = [
  "anyhow",
  "askama",
@@ -2610,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
+checksum = "8e32e261c5b0dfaba6488f536e71957dddd6b1a498ac7eb791bee56b60a086be"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2623,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
+checksum = "84ae78069a5e6772ef694fd5bdb628532c88d2c2f0e7142bf6a384636eadb1af"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2636,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
+checksum = "330be6770532e86320df31f54c70bb0be67588594e8e77fa56e9083a3fed5d0d"
 dependencies = [
  "camino",
  "fs-err",
@@ -2653,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
+checksum = "78de021f5547e56ab16c665a49d67d4fd3d31e77422f7739a2e9359d328cd9e7"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -2665,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
+checksum = "3f8201bb1907ed8a42d80e11cbc25c8a033e7a31c3cff1d911f56eedb81d4948"
 dependencies = [
  "anyhow",
  "heck",
@@ -2678,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
+checksum = "a6e57996bc58009cc29bf04845d627ae313c2547b87171c1c349d6c51a1656c0"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -2696,6 +2799,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2911,7 +3024,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3120,6 +3233,12 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rust.dead_code = "warn"
 rust.unused_variables = "warn"
 
 [workspace.dependencies]
-aes-gcm = { version = "0.10", features = ["aes"] }
+aes-gcm = { version = "0.11", features = ["aes"] }
 anyhow = "1"
 async-trait = "0.1"
 btleplug = "0.12.0"

--- a/android/lib/src/main/java/uniffi/hwcore/BleManagerHandleFactory.kt
+++ b/android/lib/src/main/java/uniffi/hwcore/BleManagerHandleFactory.kt
@@ -1,6 +1,0 @@
-package uniffi.hwcore
-
-/** Backward-compatible alias for the UniFFI-generated async factory. */
-suspend fun BleManagerHandle.Companion.new(): BleManagerHandle {
-    return create()
-}

--- a/android/lib/src/main/java/uniffi/hwcore/BleManagerHandleFactory.kt
+++ b/android/lib/src/main/java/uniffi/hwcore/BleManagerHandleFactory.kt
@@ -1,23 +1,6 @@
 package uniffi.hwcore
 
-/**
- * Factory for [BleManagerHandle] that works around uniffi 0.31 not generating
- * a Kotlin-level async constructor.  This calls the same FFI entry points that
- * the generated code uses for async methods.
- */
+/** Backward-compatible alias for the UniFFI-generated async factory. */
 suspend fun BleManagerHandle.Companion.new(): BleManagerHandle {
-    return uniffiRustCallAsync(
-        UniffiLib.uniffi_hwcore_fn_constructor_blemanagerhandle_new(),
-        { future, callback, continuation ->
-            UniffiLib.ffi_hwcore_rust_future_poll_u64(future, callback, continuation)
-        },
-        { future, continuation ->
-            UniffiLib.ffi_hwcore_rust_future_complete_u64(future, continuation)
-        },
-        { future ->
-            UniffiLib.ffi_hwcore_rust_future_free_u64(future)
-        },
-        { FfiConverterTypeBleManagerHandle.lift(it) },
-        HwCoreException.ErrorHandler,
-    )
+    return create()
 }

--- a/android/sample-app/app/src/main/java/dev/hewig/hwcore/MainViewModel.kt
+++ b/android/sample-app/app/src/main/java/dev/hewig/hwcore/MainViewModel.kt
@@ -914,7 +914,7 @@ class MainViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel(
                 log("Auto-connect: scanning for remembered device $targetId")
 
                 if (bleManager == null) {
-                    bleManager = BleManagerHandle.new()
+                    bleManager = BleManagerHandle.create()
                     log("BLE manager initialized")
                 }
                 val mgr = bleManager ?: return@launch setError("Auto-connect failed: BLE manager unavailable")
@@ -1035,7 +1035,7 @@ class MainViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel(
                     return@launch setError("Scan failed: Bluetooth is off. Turn it on and try again.")
                 }
                 if (bleManager == null) {
-                    bleManager = BleManagerHandle.new()
+                    bleManager = BleManagerHandle.create()
                     log("BLE manager initialized")
                 }
                 val mgr = bleManager ?: return@launch setError("Scan failed: BLE manager unavailable")

--- a/apple/HWCoreKit/Sources/HWCoreKit/HWCoreKit.swift
+++ b/apple/HWCoreKit/Sources/HWCoreKit/HWCoreKit.swift
@@ -12,7 +12,7 @@ public final class HWCoreKit: @unchecked Sendable {
     ) async throws -> HWCoreKit {
         do {
             try validateBluetoothUsageDescription()
-            let manager = try await BleManagerHandle()
+            let manager = try await BleManagerHandle.create()
             return HWCoreKit(manager: manager, config: config, logger: logger)
         } catch {
             throw mapError(error)

--- a/apple/HWCoreKitSampleApp/UITests/iOS/HWCoreKitSampleAppiOSUITests.swift
+++ b/apple/HWCoreKitSampleApp/UITests/iOS/HWCoreKitSampleAppiOSUITests.swift
@@ -7,51 +7,73 @@ final class HWCoreKitSampleAppiOSUITests: XCTestCase {
 
     @MainActor
     func testLaunchShowsPrimaryWorkflowControls() throws {
-        let app = XCUIApplication()
-        app.launch()
+        let app = launchApp()
 
-        XCTAssertTrue(waitForElement(app, identifier: "title.app", timeout: 15))
-        XCTAssertTrue(waitForElement(app, identifier: "state.session_phase", timeout: 10))
-        XCTAssertTrue(waitForElement(app, identifier: "action.scan", timeout: 10))
-        XCTAssertTrue(waitForElement(app, identifier: "action.connect", timeout: 10))
+        XCTAssertTrue(waitForElement(app, identifier: "title.app", timeout: 15), "Expected title.app")
+        XCTAssertTrue(waitForElement(app, identifier: "state.session_phase", timeout: 10), "Expected state.session_phase")
+        XCTAssertTrue(waitForElement(app, identifier: "action.scan", timeout: 10), "Expected action.scan")
+        XCTAssertTrue(waitForElement(app, identifier: "action.connect", timeout: 10), "Expected action.connect")
 
         let configTab = app.tabBars.buttons["Config"]
-        XCTAssertTrue(configTab.waitForExistence(timeout: 10))
+        XCTAssertTrue(configTab.waitForExistence(timeout: 10), "Expected Config tab")
         configTab.tap()
-        XCTAssertTrue(waitForElement(app, identifier: "input.address.path", timeout: 10))
-        XCTAssertTrue(waitForElement(app, identifier: "input.sign.eth.path", timeout: 10))
+        XCTAssertTrue(waitForElement(app, identifier: "input.address.path", timeout: 10), "Expected input.address.path")
+        XCTAssertTrue(waitForElement(app, identifier: "input.sign.eth.path", timeout: 10), "Expected input.sign.eth.path")
 
         let logsTab = app.tabBars.buttons["Logs"]
-        XCTAssertTrue(logsTab.waitForExistence(timeout: 10))
+        XCTAssertTrue(logsTab.waitForExistence(timeout: 10), "Expected Logs tab")
         logsTab.tap()
-        XCTAssertTrue(waitForElement(app, identifier: "logs.text", timeout: 10))
+        XCTAssertTrue(waitForElement(app, identifier: "logs.text", timeout: 10), "Expected logs.text")
     }
 
     @MainActor
     func testScanTapKeepsWorkflowUIResponsive() throws {
-        let app = XCUIApplication()
-        app.launch()
+        let app = launchApp()
 
         let scanButton = app.buttons["action.scan"]
-        XCTAssertTrue(scanButton.waitForExistence(timeout: 10))
-
-        addUIInterruptionMonitor(withDescription: "Bluetooth permission") { alert in
-            for label in ["Allow", "OK", "Don’t Allow"] {
-                if alert.buttons[label].exists {
-                    alert.buttons[label].tap()
-                    return true
-                }
-            }
-            return false
-        }
+        XCTAssertTrue(scanButton.waitForExistence(timeout: 10), "Expected action.scan")
 
         if scanButton.isHittable {
             scanButton.tap()
-            app.tap()
+            dismissBluetoothPermissionIfNeeded(app)
         }
 
-        XCTAssertTrue(waitForElement(app, identifier: "status.text", timeout: 10))
-        XCTAssertTrue(waitForElement(app, identifier: "state.session_phase", timeout: 10))
+        XCTAssertTrue(waitForElement(app, identifier: "status.text", timeout: 10), "Expected status.text")
+        XCTAssertTrue(waitForElement(app, identifier: "state.session_phase", timeout: 10), "Expected state.session_phase")
+    }
+
+    private func launchApp() -> XCUIApplication {
+        addUIInterruptionMonitor(withDescription: "Bluetooth permission") { [weak self] alert in
+            self?.tapFirstMatchingPermissionButton(in: alert) ?? false
+        }
+
+        let app = XCUIApplication()
+        app.launch()
+        dismissBluetoothPermissionIfNeeded(app)
+        return app
+    }
+
+    private func dismissBluetoothPermissionIfNeeded(_ app: XCUIApplication) {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let alert = springboard.alerts.firstMatch
+        if alert.waitForExistence(timeout: 2) {
+            _ = tapFirstMatchingPermissionButton(in: alert)
+            return
+        }
+
+        app.tap()
+    }
+
+    private func tapFirstMatchingPermissionButton(in alert: XCUIElement) -> Bool {
+        for label in ["Allow", "OK", "Don’t Allow", "Don't Allow"] {
+            let button = alert.buttons[label]
+            if button.exists {
+                button.tap()
+                return true
+            }
+        }
+
+        return false
     }
 
     private func waitForElement(

--- a/crates/hw-ffi/Cargo.toml
+++ b/crates/hw-ffi/Cargo.toml
@@ -30,12 +30,12 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tracing = { workspace = true }
 trezor-connect = { workspace = true, features = ["ble"] }
-uniffi = { version = "0.31.0", features = ["tokio"] }
+uniffi = { version = "0.32.0", features = ["tokio"] }
 uuid = { workspace = true }
 anyhow = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 camino = { version = "1", optional = true }
-uniffi_bindgen = { version = "0.31.0", features = [
+uniffi_bindgen = { version = "0.32.0", features = [
     "cargo-metadata",
 ], optional = true }
 

--- a/crates/hw-ffi/src/ble.rs
+++ b/crates/hw-ffi/src/ble.rs
@@ -43,19 +43,13 @@ pub struct BleManagerHandle {
     manager: BleManager,
 }
 
-impl BleManagerHandle {
-    pub async fn new() -> Result<Self, HWCoreError> {
-        crate::init_platform_tracing_once();
-        let manager = BleManager::new().await.map_err(HWCoreError::from)?;
-        Ok(Self { manager })
-    }
-}
-
 #[uniffi::export(async_runtime = "tokio")]
 impl BleManagerHandle {
     #[uniffi::constructor]
     pub async fn create() -> Result<Self, HWCoreError> {
-        Self::new().await
+        crate::init_platform_tracing_once();
+        let manager = BleManager::new().await.map_err(HWCoreError::from)?;
+        Ok(Self { manager })
     }
 
     #[uniffi::method]

--- a/crates/hw-ffi/src/ble.rs
+++ b/crates/hw-ffi/src/ble.rs
@@ -43,13 +43,19 @@ pub struct BleManagerHandle {
     manager: BleManager,
 }
 
-#[uniffi::export(async_runtime = "tokio")]
 impl BleManagerHandle {
-    #[uniffi::constructor]
     pub async fn new() -> Result<Self, HWCoreError> {
         crate::init_platform_tracing_once();
         let manager = BleManager::new().await.map_err(HWCoreError::from)?;
         Ok(Self { manager })
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl BleManagerHandle {
+    #[uniffi::constructor]
+    pub async fn create() -> Result<Self, HWCoreError> {
+        Self::new().await
     }
 
     #[uniffi::method]

--- a/crates/hw-ffi/tests/emu_ble.rs
+++ b/crates/hw-ffi/tests/emu_ble.rs
@@ -16,7 +16,9 @@ async fn emu_ble_ffi_connect_ready_and_get_eth_address() {
     let harness = EmulatorHarness::start();
     set_dbus_system_bus_address(harness.dbus_system_bus_address());
 
-    let manager = BleManagerHandle::new().await.expect("create BLE manager");
+    let manager = BleManagerHandle::create()
+        .await
+        .expect("create BLE manager");
     let devices = manager
         .discover_trezor(8_000)
         .await
@@ -63,7 +65,9 @@ async fn emu_ble_ffi_sign_eth_message() {
     let harness = EmulatorHarness::start();
     set_dbus_system_bus_address(harness.dbus_system_bus_address());
 
-    let manager = BleManagerHandle::new().await.expect("create BLE manager");
+    let manager = BleManagerHandle::create()
+        .await
+        .expect("create BLE manager");
     let devices = manager
         .discover_trezor(8_000)
         .await

--- a/crates/trezor-connect/src/thp/crypto/tools.rs
+++ b/crates/trezor-connect/src/thp/crypto/tools.rs
@@ -1,4 +1,4 @@
-use aes_gcm::aead::{AeadInPlace, Error as AeadError, KeyInit, Tag};
+use aes_gcm::aead::{AeadInOut, Error as AeadError, KeyInit, Tag};
 use aes_gcm::{Aes256Gcm, Nonce};
 use hmac::{Hmac, Mac};
 use num_bigint::{BigInt, Sign};
@@ -53,7 +53,8 @@ pub fn aes256gcm_encrypt(
     let cipher = Aes256Gcm::new(key.into());
     let nonce = Nonce::from(*iv);
     let mut buffer = plaintext.to_vec();
-    let tag: Tag<Aes256Gcm> = cipher.encrypt_in_place_detached(&nonce, aad, &mut buffer)?;
+    let tag: Tag<Aes256Gcm> =
+        cipher.encrypt_inout_detached(&nonce, aad, buffer.as_mut_slice().into())?;
     let mut tag_bytes = [0u8; 16];
     tag_bytes.copy_from_slice(tag.as_ref());
     Ok((buffer, tag_bytes))
@@ -70,7 +71,7 @@ pub fn aes256gcm_decrypt(
     let nonce = Nonce::from(*iv);
     let mut buffer = ciphertext.to_vec();
     let tag_array = Tag::<Aes256Gcm>::from(*tag);
-    cipher.decrypt_in_place_detached(&nonce, aad, &mut buffer, &tag_array)?;
+    cipher.decrypt_inout_detached(&nonce, aad, buffer.as_mut_slice().into(), &tag_array)?;
     Ok(buffer)
 }
 


### PR DESCRIPTION
## Summary

Supersedes #64, #65, and #66 with one dependency-rollup PR.

- Bumps `aes-gcm` to 0.11 for workspace crates and migrates THP AES-GCM helpers from deprecated `AeadInPlace` calls to `AeadInOut`.
- Bumps `uniffi` and `uniffi_bindgen` together to 0.32.0 so generated bindings and runtime metadata stay in sync.
- Changes the exported BLE manager factory from an async primary constructor to `BleManagerHandle.create()`, while keeping Rust `BleManagerHandle::new()` and the Kotlin `BleManagerHandle.new()` compatibility alias.

## CI failures fixed

- #64 failed Rust CI because `aes-gcm 0.11` deprecates `AeadInPlace` under `-D warnings`.
- #65 and #66 failed iOS/Android binding generation because UniFFI runtime and bindgen were upgraded separately and could not decode each other's metadata.
- The combined update also handles UniFFI 0.32's Kotlin restriction on async primary constructors.

## Validation

- `just fmt && just lint`
- `just ci`
- `just bindings`
- `cargo check -p hw-ffi --target aarch64-apple-ios`
- `just build-android`
- `just generate-apple-projects`
- `swift test --package-path apple/HWCoreKit`
- `just smoke-ios-ui`
- `xcodebuild -project apple/HWCoreKitSampleApp/HWCoreKitSampleAppMac.xcodeproj -scheme HWCoreKitSampleAppMac -destination 'platform=macOS' build | xcbeautify`
- `./gradlew :lib:assembleDebug --no-daemon`
- `./gradlew :lib:testDebugUnitTest --no-daemon`
- `./gradlew :sample-app:app:assembleDebug --no-daemon`